### PR TITLE
Actions copy() fixes.

### DIFF
--- a/cocos2d/actions/CCActionInstant.js
+++ b/cocos2d/actions/CCActionInstant.js
@@ -326,6 +326,12 @@ cc.CallFunc = cc.ActionInstant.extend(/** @lends cc.CallFunc# */{
             this._selectorTarget = sel;
         }
     },
+
+    copy:function() {
+        var n = new cc.CallFunc();
+        n.initWithTarget( this._selectorTarget, this._callFunc, this._data );
+        return n;
+    },
     _selectorTarget:null,
     _callFunc:null
 });

--- a/cocos2d/actions/CCActionInterval.js
+++ b/cocos2d/actions/CCActionInterval.js
@@ -242,7 +242,15 @@ cc.Sequence = cc.ActionInterval.extend(/** @lends cc.Sequence# */{
      */
     reverse:function () {
         return cc.Sequence._actionOneTwo(this._actions[1].reverse(), this._actions[0].reverse());
-    }
+    },
+
+    /**
+     * to copy object with deep copy.
+     * @return {object}
+     */
+    copy:function () {
+        return cc.Sequence._actionOneTwo(this._actions[0].copy(), this._actions[1].copy() );
+    },
 });
 /** helper constructor to create an array of sequenceable actions
  * @param {Array|cc.FiniteTimeAction} tempArray


### PR DESCRIPTION
There was an infity recursion if you copy a CallFunc.
Apparently cc.clone() was not handling an specially case.

I also added an explicity copy for sequence, since I think it is going
to be faster.
