### PR TITLE
Changes needed to make it compatible with cocos2d + JS bindings

### DIFF
--- a/cocos2d/cocoa/CCGeometry.js
+++ b/cocos2d/cocoa/CCGeometry.js
@@ -237,6 +237,15 @@ cc.Rect.CCRectIntersectsRect = function (rectA, rectB) {
  * @return {Boolean}
  * Constructor
  */
+cc.rectIntersectsRect = cc.Rect.CCRectIntersectsRect;
+
+/**
+ * @function
+ * @param {cc.Rect} rectA
+ * @param {cc.Rect} rectB
+ * @return {Boolean}
+ * Constructor
+ */
 cc.Rect.CCRectOverlapsRect = function (rectA, rectB) {
     if (rectA.origin.x + rectA.size.width < rectB.origin.x) {
         return false;

--- a/cocos2d/menu_nodes/CCMenuItem.js
+++ b/cocos2d/menu_nodes/CCMenuItem.js
@@ -107,7 +107,7 @@ cc.MenuItem = cc.Node.extend(/** @lends cc.MenuItem# */{
      * @param {function|String} selector
      * @return {Boolean}
      */
-    initWithTarget:function (rec, selector) {
+    initWithCallback:function (rec, selector) {
         this.setAnchorPoint(cc.p(0.5, 0.5));
         this._listener = rec;
         this._selector = selector;
@@ -143,7 +143,7 @@ cc.MenuItem = cc.Node.extend(/** @lends cc.MenuItem# */{
      * @param {cc.Node} rec
      * @param {function|String} selector
      */
-    setTarget:function (rec, selector) {
+    setCallback:function (rec, selector) {
         this._listener = rec;
         this._selector = selector;
     },
@@ -171,7 +171,7 @@ cc.MenuItem = cc.Node.extend(/** @lends cc.MenuItem# */{
  */
 cc.MenuItem.create = function (rec, selector) {
     var ret = new cc.MenuItem();
-    ret.initWithTarget(rec, selector);
+    ret.initWithCallback(rec, selector);
     return ret;
 };
 
@@ -290,7 +290,7 @@ cc.MenuItemLabel = cc.MenuItem.extend(/** @lends cc.MenuItemLabel# */{
      * @return {Boolean}
      */
     initWithLabel:function (label, target, selector) {
-        this.initWithTarget(target, selector);
+        this.initWithCallback(target, selector);
         this._originalScale = 1.0;
         this._colorBackup = cc.WHITE;
         this._disabledColor = cc.c3b(126, 126, 126);
@@ -642,7 +642,7 @@ cc.MenuItemSprite = cc.MenuItem.extend(/** @lends cc.MenuItemSprite# */{
      * @return {Boolean}
      */
     initWithNormalSprite:function (normalSprite, selectedSprite, disabledSprite, target, selector) {
-        this.initWithTarget(target, selector);
+        this.initWithCallback(target, selector);
         this.setNormalImage(normalSprite);
         this.setSelectedImage(selectedSprite);
         this.setDisabledImage(disabledSprite);
@@ -1035,9 +1035,26 @@ cc.MenuItemToggle = cc.MenuItem.extend(/** @lends cc.MenuItemToggle# */{
      * @return {Boolean}
      */
     initWithItem:function (item) {
-        this.initWithTarget(null, null);
+        this.initWithCallback(null, null);
         this._subItems = [];
         this._subItems.push(item);
+        this._selectedIndex = cc.UINT_MAX;
+        this.setSelectedIndex(0);
+        return true;
+    },
+
+    /**
+     * @param {cc.MenuItem} args[1+] items
+     * @return {Boolean}
+     */
+    initWithItems:function (args) {
+        this.initWithCallback(null, null);
+        this._subItems = [];
+        for (var i = 0; i < args.length; i++) {
+            if (args[i]) {
+                this._subItems.push(args[i]);
+            }
+        }
         this._selectedIndex = cc.UINT_MAX;
         this.setSelectedIndex(0);
         return true;
@@ -1131,10 +1148,11 @@ cc.MenuItemToggle = cc.MenuItem.extend(/** @lends cc.MenuItemToggle# */{
  */
 cc.MenuItemToggle.create = function (/*Multiple arguments follow*/) {
     var ret = new cc.MenuItemToggle();
-    if (arguments.length == 1) {
-        ret.initWithItem(arguments);
-    } else {
-        ret.initWithTarget(arguments);
-    }
+    ret.initWithItems(arguments);
+//    if (arguments.length == 1) {
+//        ret.initWithItem(arguments);
+//    } else {
+//        ret.initWithTarget(arguments);
+//    }
     return ret;
 };

--- a/cocos2d/platform/CCCommon.js
+++ b/cocos2d/platform/CCCommon.js
@@ -47,6 +47,15 @@ cc.clone = function (obj) {
 };
 
 /**
+ * Function added for JS bindings compatibility. Not needed in cocos2d-html5.
+ * @function
+ * @param {object} jsobj subclass
+ * @param {object} klass superclass
+ */
+cc.associateWithNative = function( jsobj, superclass ) {
+};
+
+/**
  * Is show bebug info on web page
  * @constant
  * @type {Boolean}

--- a/cocos2d/sprite_nodes/CCAnimation.js
+++ b/cocos2d/sprite_nodes/CCAnimation.js
@@ -385,15 +385,3 @@ cc.Animation.createWithAnimationFrames = function (arrayOfAnimationFrameNames, d
     return animation;
 };
 
-/**
- * Creates an animation with an array of cc.SpriteFrame and a delay between frames in seconds. The frames will be added with one "delay unit".
- * @param {Array} arrayOfSpriteFrameNames
- * @param {Number} delay
- * @return {cc.Animation}
- */
-cc.Animation.createWithSpriteFrames = function (arrayOfSpriteFrameNames, delay) {
-    var animation = new cc.Animation();
-    animation.initWithSpriteFrames(arrayOfSpriteFrameNames, delay);
-    return animation;
-};
-

--- a/tests/src/tests/SpriteTest/SpriteTest.js
+++ b/tests/src/tests/SpriteTest/SpriteTest.js
@@ -1544,7 +1544,7 @@ var SpriteFrameTest = SpriteTestDemo.extend({
             animFrames.push(frame);
         }
 
-        var animation = cc.Animation.createWithSpriteFrames(animFrames, 0.3);
+        var animation = cc.Animation.create(animFrames, 0.3);
         this._sprite1.runAction(cc.RepeatForever.create(cc.Animate.create(animation)));
 
         // to test issue #732, uncomment the following line
@@ -1573,7 +1573,7 @@ var SpriteFrameTest = SpriteTestDemo.extend({
 
         // append frames from another batch
         moreFrames = moreFrames.concat(animFrames);
-        var animMixed = cc.Animation.createWithSpriteFrames(moreFrames, 0.3);
+        var animMixed = cc.Animation.create(moreFrames, 0.3);
 
         this._sprite2.runAction(cc.RepeatForever.create(cc.Animate.create(animMixed)));
 
@@ -1687,7 +1687,7 @@ var SpriteFrameAliasNameTest = SpriteTestDemo.extend({
             animFrames.push(frame);
         }
 
-        var animation = cc.Animation.createWithSpriteFrames(animFrames, 0.3);
+        var animation = cc.Animation.create(animFrames, 0.3);
         // 14 frames * 1sec = 14 seconds
         sprite.runAction(cc.RepeatForever.create(cc.Animate.create(animation)));
     },
@@ -1743,7 +1743,7 @@ var SpriteOffsetAnchorRotation = SpriteTestDemo.extend({
                 animFrames.push(frame);
             }
 
-            var animation = cc.Animation.createWithSpriteFrames(animFrames, 0.3);
+            var animation = cc.Animation.create(animFrames, 0.3);
             sprite.runAction(cc.RepeatForever.create(cc.Animate.create(animation)));
             sprite.runAction(cc.RepeatForever.create(cc.RotateBy.create(10, 360)));
 
@@ -1810,7 +1810,7 @@ var SpriteBatchNodeOffsetAnchorRotation = SpriteTestDemo.extend({
                 animFrames.push(frame);
             }
 
-            var animation = cc.Animation.createWithSpriteFrames(animFrames, 0.3);
+            var animation = cc.Animation.create(animFrames, 0.3);
             sprite.runAction(cc.RepeatForever.create(cc.Animate.create(animation)));
             sprite.runAction(cc.RepeatForever.create(cc.RotateBy.create(10, 360)));
 
@@ -1875,7 +1875,7 @@ var SpriteOffsetAnchorScale = SpriteTestDemo.extend({
                 animFrames.push(frame);
             }
 
-            var animation = cc.Animation.createWithSpriteFrames(animFrames, 0.3);
+            var animation = cc.Animation.create(animFrames, 0.3);
             sprite.runAction(cc.RepeatForever.create(cc.Animate.create(animation)));
 
             var scale = cc.ScaleBy.create(2, 2);
@@ -1948,7 +1948,7 @@ var SpriteBatchNodeOffsetAnchorScale = SpriteTestDemo.extend({
                 animFrames.push(frame);
             }
 
-            var animation = cc.Animation.createWithSpriteFrames(animFrames, 0.3);
+            var animation = cc.Animation.create(animFrames, 0.3);
             sprite.runAction(cc.RepeatForever.create(cc.Animate.create(animation)));
 
             var scale = cc.ScaleBy.create(2, 2);
@@ -2015,7 +2015,7 @@ var SpriteOffsetAnchorSkew = SpriteTestDemo.extend({
                 animFrames.push(frame);
             }
 
-            var animation = cc.Animation.createWithSpriteFrames(animFrames, 0.3);
+            var animation = cc.Animation.create(animFrames, 0.3);
             sprite.runAction(cc.RepeatForever.create(cc.Animate.create(animation)));
 
             var skewX = cc.SkewBy.create(2, 45, 0);
@@ -2082,7 +2082,7 @@ var SpriteBatchNodeOffsetAnchorSkew = SpriteTestDemo.extend({
                 animFrames.push(frame);
             }
 
-            var animation = cc.Animation.createWithSpriteFrames(animFrames, 0.3);
+            var animation = cc.Animation.create(animFrames, 0.3);
             sprite.runAction(cc.RepeatForever.create(cc.Animate.create(animation)));
 
             animFrames = null;
@@ -2148,7 +2148,7 @@ var SpriteOffsetAnchorSkewScale = SpriteTestDemo.extend({
                 animFrames.push(frame);
             }
 
-            var animation = cc.Animation.createWithSpriteFrames(animFrames, 0.3);
+            var animation = cc.Animation.create(animFrames, 0.3);
             sprite.runAction(cc.RepeatForever.create(cc.Animate.create(animation)));
 
             animFrames = null;
@@ -2224,7 +2224,7 @@ var SpriteBatchNodeOffsetAnchorSkewScale = SpriteTestDemo.extend({
                 animFrames.push(frame);
             }
 
-            var animation = cc.Animation.createWithSpriteFrames(animFrames, 0.3);
+            var animation = cc.Animation.create(animFrames, 0.3);
             sprite.runAction(cc.RepeatForever.create(cc.Animate.create(animation)));
 
             animFrames = null;
@@ -2297,7 +2297,7 @@ var SpriteOffsetAnchorFlip = SpriteTestDemo.extend({
                 animFrames.push(frame);
             }
 
-            var animation = cc.Animation.createWithSpriteFrames(animFrames, 0.3);
+            var animation = cc.Animation.create(animFrames, 0.3);
             sprite.runAction(cc.RepeatForever.create(cc.Animate.create(animation)));
 
             animFrames = null;
@@ -2368,7 +2368,7 @@ var SpriteBatchNodeOffsetAnchorFlip = SpriteTestDemo.extend({
                 animFrames.push(frame);
             }
 
-            var animation = cc.Animation.createWithSpriteFrames(animFrames, 0.3);
+            var animation = cc.Animation.create(animFrames, 0.3);
             sprite.runAction(cc.RepeatForever.create(cc.Animate.create(animation)));
 
             animFrames = null;
@@ -2423,7 +2423,7 @@ var SpriteAnimationSplit = SpriteTestDemo.extend({
         animFrames.push(frame4);
         animFrames.push(frame5);
 
-        var animation = cc.Animation.createWithSpriteFrames(animFrames, 0.2);
+        var animation = cc.Animation.create(animFrames, 0.2);
         var animate = cc.Animate.create(animation);
         var seq = cc.Sequence.create(animate,
             cc.FlipX.create(true),
@@ -2568,7 +2568,7 @@ var SpriteBatchNodeChildren = SpriteTestDemo.extend({
             animFrames.push(frame);
         }
 
-        var animation = cc.Animation.createWithSpriteFrames(animFrames, 0.2);
+        var animation = cc.Animation.create(animFrames, 0.2);
         sprite1.runAction(cc.RepeatForever.create(cc.Animate.create(animation)));
         // END NEW CODE
 
@@ -3370,7 +3370,7 @@ var AnimationCache = SpriteTestDemo.extend({
             animFrames.push(frame);
         }
 
-        var animation = cc.Animation.createWithSpriteFrames(animFrames, 0.2);
+        var animation = cc.Animation.create(animFrames, 0.2);
 
         // Add an animation to the Cache
         cc.AnimationCache.getInstance().addAnimation(animation, "dance");
@@ -3385,7 +3385,7 @@ var AnimationCache = SpriteTestDemo.extend({
             animFrames.push(frame);
         }
 
-        animation = cc.Animation.createWithSpriteFrames(animFrames, 0.2);
+        animation = cc.Animation.create(animFrames, 0.2);
 
         // Add an animation to the Cache
         cc.AnimationCache.getInstance().addAnimation(animation, "dance_gray");
@@ -3400,7 +3400,7 @@ var AnimationCache = SpriteTestDemo.extend({
             animFrames.push(frame);
         }
 
-        animation = cc.Animation.createWithSpriteFrames(animFrames, 0.2);
+        animation = cc.Animation.create(animFrames, 0.2);
 
         // Add an animation to the Cache
         cc.AnimationCache.getInstance().addAnimation(animation, "dance_blue");


### PR DESCRIPTION
Added "cc.associateWithNative": It does nothing, but needed for compatibility.
MenuItem: Changed the API a bit:
  -> OLD: setTarget   NEW: setCallback
  -> ToggleMenuItem: initializes with a list of items. The callback is
       set manually later (I have some doubts about this change, but it
       is a bit better than the previous one)
Animation:  OLD: createWithSpriteFrames    NEW: create
Geometry: Started the new "rectIntersection" API... but I have not
          finished it yet.

Updates the tests.

These changes are needed for the MoonWarrior coco2d+js bindings version.

TODO in cocos2d-html5:
- Finish rect and size API and merge them in one file
- Since touches events are not avaible in cocos2d-html5, it should be renamed
  to "mouse events"
