### PR TITLE
issue: box2d library is not able to be used by node.js require system without adding the following line:

### DIFF
--- a/box2d/box2d.js
+++ b/box2d/box2d.js
@@ -10876,3 +10876,5 @@ Box2D.postDefs = [];
 var i;
 for (i = 0; i < Box2D.postDefs.length; ++i) Box2D.postDefs[i]();
 delete Box2D.postDefs;
+
+module.exports = Box2D;


### PR DESCRIPTION
issue: box2d library is not able to be used by node.js require system without adding the following line:

module.exports = Box2D;

this allows the library to be used in both server and client without major modification
