### PR TITLE
Calls FileUtils for path conversion

### DIFF
--- a/cocos2d/platform/CCFileUtils.js
+++ b/cocos2d/platform/CCFileUtils.js
@@ -91,6 +91,8 @@ cc.FileUtils = cc.Class.extend({
     },
 
     preloadBinaryFileData:function(fileUrl){
+        fileUrl = this.fullPathFromRelativePath(fileUrl);
+
         var selfPointer = this;
         var xhr = new XMLHttpRequest();
         xhr.open("GET", fileUrl, true);

--- a/cocos2d/platform/CCSAXParser.js
+++ b/cocos2d/platform/CCSAXParser.js
@@ -162,6 +162,8 @@ cc.SAXParser = cc.Class.extend(/** @lends cc.SAXParser# */{
      * @param {String} filePath
      */
     preloadPlist:function (filePath) {
+        filePath = cc.FileUtils.getInstance().fullPathFromRelativePath(filePath);
+
         if (window.XMLHttpRequest) {
             // for IE7+, Firefox, Chrome, Opera, Safari brower
             var xmlhttp = new XMLHttpRequest();

--- a/cocos2d/textures/CCTextureCache.js
+++ b/cocos2d/textures/CCTextureCache.js
@@ -90,6 +90,9 @@ cc.TextureCache = cc.Class.extend(/** @lends cc.TextureCache# */{
      */
     addImageAsync:function (path, target, selector) {
         cc.Assert(path != null, "TextureCache: path MUST not be null");
+
+        path = cc.FileUtils.getInstance().fullPathFromRelativePath(path);
+
         var texture = this.textures[path.toString()];
 
         if (texture) {
@@ -148,6 +151,9 @@ cc.TextureCache = cc.Class.extend(/** @lends cc.TextureCache# */{
      */
     addImage:function (path) {
         cc.Assert(path != null, "TextureCache: path MUST not be null");
+
+        path = cc.FileUtils.getInstance().fullPathFromRelativePath(path);
+
         var texture = this.textures[path.toString()];
         if (texture) {
             cc.Loader.getInstance().onResLoaded();
@@ -354,6 +360,8 @@ cc.TextureCache = cc.Class.extend(/** @lends cc.TextureCache# */{
      */
     addPVRImage:function (path) {
         cc.Assert(path != null, "TextureCache: file image MUST not be null");
+
+        path = cc.FileUtils.getInstance().fullPathFromRelativePath(path);
 
         var key = path;
 


### PR DESCRIPTION
All path should call filetutils before being opened.
The default behavior is: return the same path
But most probably users will like to override the default behavior with some renaming rules like:
- "all .png should be downloaded from this URI".
