### PR TITLE
jsb bug

### DIFF
--- a/cocos2d/actions/CCAction.js
+++ b/cocos2d/actions/CCAction.js
@@ -167,6 +167,15 @@ cc.Action = cc.Class.extend(/** @lends cc.Action# */{
      */
     setTag:function (tag) {
         this._tag = tag;
+    },
+    /**
+     * Currently JavaScript Bindigns (JSB), in some cases, needs to use retain and release. This is a bug in JSB,
+     * and the ugly workaround is to use retain/release. So, these 2 methods were added to be compatible with JSB.
+     * This is a hack, and should be removed once JSB fixes the retain/release bug
+     */
+    retain:function () {
+    },
+    release:function () {
     }
 });
 /** Allocates and initializes the action


### PR DESCRIPTION
Currently JavaScript Bindigns (JSB), in some cases, needs to use retain and release. This is a bug in JSB, and the ugly workaround is to use retain/release. So, these 2 methods were added to be compatible with JSB. This is a hack, and should be removed once JSB fixes the retain/release bug
