### PR TITLE
ccClass fix

### DIFF
--- a/cocos2d/label_nodes/CCLabelBMFont.js
+++ b/cocos2d/label_nodes/CCLabelBMFont.js
@@ -154,7 +154,7 @@ cc.BMFontConfiguration = cc.Class.extend(/** @lends cc.BMFontConfiguration# */{
     },
 
     _parseConfigFile:function (controlFile) {
-        var data = cc.SAXParser.getInstance().getList(cc.FileUtils.getInstance().fullPathFromRelativePath(controlFile));
+        var data = cc.SAXParser.getInstance().getList(controlFile);
         cc.Assert(data, "cc.BMFontConfiguration._parseConfigFile | Open file error.");
 
         // parse spacing / padding


### PR DESCRIPTION
If there is no document.ccConfig, accessing document.ccConfig.foo will result in `Uncaught TypeError: Cannot read property 'CLASS_RELEASE_MODE' of undefined`
