### PR TITLE
DrawNode fix 2:

### DIFF
--- a/cocos2d/Draw_Nodes/CCDrawNode.js
+++ b/cocos2d/Draw_Nodes/CCDrawNode.js
@@ -275,10 +275,10 @@ cc.DrawNode = cc.Node.extend({
     },
 
     /** draw a polygon with a fill color and line color */
-    drawPolyWithVerts:function (verts, count, fillColor, width, borderColor) {
+    drawPoly:function (verts, fillColor, width, borderColor) {
         var element = new cc._DrawNodeElement(cc.DRAWNODE_TYPE_POLY);
-        element.verts = cc.DrawNode.convertVerts(verts);
-        element.count = count;
+        element.verts = verts;
+        element.count = verts.length;
         element.fillColor = fillColor;
         element.borderWidth = width;
         element.borderColor = borderColor;
@@ -395,10 +395,3 @@ cc._DrawNodeElement = function (type) {
 cc.DRAWNODE_TYPE_DOT = 0;
 cc.DRAWNODE_TYPE_SEGMENT = 1;
 cc.DRAWNODE_TYPE_POLY = 2;
-cc.DrawNode.convertVerts = function (verts) {
-    var ret = [];
-    for (var i = 0; i < verts.length / 2; i++) {
-        ret[i] = {x:verts[i * 2], y:verts[i * 2 + 1]};
-    }
-    return ret;
-};

--- a/cocos2d/physics_nodes/CCPhysicsDebugNode.js
+++ b/cocos2d/physics_nodes/CCPhysicsDebugNode.js
@@ -34,6 +34,15 @@
  as the private API may change with little or no warning.
  */
 
+// Helper. Converts an array of numbers into an array of vectors(x,y)
+cc.__convertVerts = function (verts) {
+    var ret = [];
+    for (var i = 0; i < verts.length / 2; i++) {
+        ret[i] = {x:verts[i * 2], y:verts[i * 2 + 1]};
+    }
+    return ret;
+};
+
 cc.ColorForBody = function (body) {
     if (body.isRogue() || body.isSleeping()) {
         return cc.c4f(0.5, 0.5, 0.5, 0.5);
@@ -57,7 +66,7 @@ cc.DrawShape = function (shape, renderer) {
             break;
         case cp.PolyShape.prototype.collisionCode:
             var line = cc.c4f(color.r, color.g, color.b, cc.lerp(color.a, 1.0, 0.5));
-            this.drawPolyWithVerts(shape.tVerts, shape.getNumVerts(), color, 1.0, line);
+            this.drawPoly(cc.__convertVerts(shape.tVerts), color, 1.0, line);
             break;
         default:
             cc.Assert(false, "Bad assertion in DrawShape()");
@@ -154,3 +163,4 @@ cc.PhysicsDebugNode.debugNodeForCPSpace = function (space) {
 };
 
 cc.PhysicsDebugNode.create = cc.PhysicsDebugNode.debugNodeForCPSpace;
+


### PR DESCRIPTION
Ignore previous patch.
DrawNode is compatible with JSB.
