### PR TITLE
Adds sys.localStorage support

### DIFF
--- a/System/LocalStorage.js
+++ b/System/LocalStorage.js
@@ -1,0 +1,30 @@
+/****************************************************************************
+
+ http://www.cocos2d-html5.org
+ http://www.cocos2d-iphone.org
+ http://www.cocos2d-x.org
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
+var sys = sys || {};
+
+/** LocalStorage is a local storage component.
+*/
+sys.localStorage = window.localStorage;

--- a/cocos2d/platform/jsloader.js
+++ b/cocos2d/platform/jsloader.js
@@ -106,7 +106,8 @@
         'menu_nodes/CCMenuItem.js',
         'menu_nodes/CCMenu.js',
         'base_nodes/CCdomNode.js',
-        '../CocosDenshion/SimpleAudioEngine.js'
+        '../CocosDenshion/SimpleAudioEngine.js',
+        '../System/LocalStorage.js'
     ];
 
     var d = document;


### PR DESCRIPTION
The "sys" namespace is for all the system components, like
localStorage.
Since html5 already has a local storage support, sys.localStorage is
the same as window.localStorage.
But it uses "sys" for JSB compatibility.
