### PR TITLE
fixed 'chunky' position for nodes when scaled

### DIFF
--- a/cocos2d/base_nodes/CCNode.js
+++ b/cocos2d/base_nodes/CCNode.js
@@ -1342,15 +1342,15 @@ cc.Node = cc.Class.extend(/** @lends cc.Node# */{
         // transformations
         if (!this._ignoreAnchorPointForPosition) {
             if (this._parent)
-                context.translate(0 | (this._position.x - this._parent._anchorPointInPoints.x), -(0 | (this._position.y - this._parent._anchorPointInPoints.y)));
+                context.translate((this._position.x - this._parent._anchorPointInPoints.x), -((this._position.y - this._parent._anchorPointInPoints.y)));
             else
-                context.translate(0 | this._position.x, -(0 | this._position.y));
+                context.translate(this._position.x, -(this._position.y));
         } else {
             if (this._parent) {
-                context.translate(0 | ( this._position.x - this._parent._anchorPointInPoints.x + this._anchorPointInPoints.x),
-                    -(0 | (this._position.y - this._parent._anchorPointInPoints.y + this._anchorPointInPoints.y)));
+                context.translate(( this._position.x - this._parent._anchorPointInPoints.x + this._anchorPointInPoints.x),
+                    -((this._position.y - this._parent._anchorPointInPoints.y + this._anchorPointInPoints.y)));
             } else {
-                context.translate(0 | ( this._position.x + this._anchorPointInPoints.x), -(0 | (this._position.y + this._anchorPointInPoints.y)));
+                context.translate(( this._position.x + this._anchorPointInPoints.x), -((this._position.y + this._anchorPointInPoints.y)));
             }
         }
 


### PR DESCRIPTION
Node positions were rounded to whole coordinates when the container/layer had a scale greater than 1. There was a bit-wise or (0 | ....), when using this with decimal numbers, the decimal part of the number is removed. (0 | 1.5 will result in 1). I don't know why this comparison was in there, probably because to prevent errors when an invalid number was supplied.

I discovered this issue when using a MoveTo action in combination with a scaled layer. This fix resolves the issue, though it may cause problems when a wrong position is given (or anchor point)
