### PR TITLE
fixing issue when calling setEffectsVolume() before playEffect()

### DIFF
--- a/CocosDenshion/SimpleAudioEngine.js
+++ b/CocosDenshion/SimpleAudioEngine.js
@@ -331,6 +331,7 @@ cc.AudioEngine = cc.Class.extend(/** @lends cc.AudioEngine# */{
                 return path;
             }
             au = new Audio(keyname + "." + actExt);
+            au.volume = this._effectsVolume;
             reclaim.push(au);
         }
 


### PR DESCRIPTION
This should fix two things:
1. If you call setEffectsVolume() before calling playEffect(), the effect doesn't use the volume that you set.
2. If you repeatedly call playEffect(), sometimes (whenever a new audio instance has to be created) the effect will play at a different volume.

You can see this In the CocosDenshion test:
1. Click "Decrease Sound Effect Volume" more than 10 times. The volume should be 0. When you click "Play Sound Effect" you should hear nothing. Instead, the audio will currently play at full volume. If you click change the sound effect volume again, it will play at the correct volume.
2. Decrease the sound effect volume to 0. Make sure that when you click "Play Sound Effect" you hear nothing. Now repeatedly click "Play Sound Effect" as fast as you can. You should expect to hear nothing. Instead, you will hear the effect sometimes.
3. If you unload the sound effect, the volume will also be reset.

On a related note, the background music has a similar problem, but it looks like more change is needed to fix it.

I'm testing this on Chromium Version 24.0.1312.56 Ubuntu 12.10 (24.0.1312.56-0ubuntu0.12.10.3) and Firefox for Ubuntu 19.0
