### PR TITLE
Bugfixes in CCScale9Sprite

### DIFF
--- a/extensions/GUI/CCControlExtension/CCScale9Sprite.js
+++ b/extensions/GUI/CCControlExtension/CCScale9Sprite.js
@@ -334,7 +334,7 @@ cc.Scale9Sprite = cc.Node.extend({
         var scaleChildren = this._scale9Image.getChildren();
         if (scaleChildren && scaleChildren.length != 0) {
             for (var i = 0; i < scaleChildren.length; i++) {
-                if (scaleChildren[i] && scaleChildren.RGBAProtocol) {
+                if (scaleChildren[i] && scaleChildren[i].RGBAProtocol) {
                     scaleChildren[i].setOpacityModifyRGB(this._isOpacityModifyRGB);
                 }
             }


### PR DESCRIPTION
fixes: Bug in CCScale9Sprite, changed scaleChildren.RGBAProtocol to scaleChildren[i].RGBAProtocol in order to work.
