### PR TITLE
Fix for CCEGLView.js touches* function when adding to Array.prototype

### DIFF
--- a/cocos2d/platform/CCEGLView.js
+++ b/cocos2d/platform/CCEGLView.js
@@ -548,10 +548,10 @@ cc.EGLView = cc.Class.extend(/** @lends cc.EGLView# */{
         var ys = [];
 
         var i = 0;
-        for (var key in touches) {
-            ids[i] = key;
-            xs[i] = touches[key].getLocation().x;
-            ys[i] = touches[key].getLocation().y;
+        for (var j = 0; j < touches.length; j++) {
+            ids[i] = j;
+            xs[i] = touches[j].getLocation().x;
+            ys[i] = touches[j].getLocation().y;
             ++i;
         }
         this.handleTouchesBegin(i, ids, xs, ys);
@@ -562,10 +562,10 @@ cc.EGLView = cc.Class.extend(/** @lends cc.EGLView# */{
         var ys = [];
 
         var i = 0;
-        for (var key in touches) {
-            ids[i] = key;
-            xs[i] = touches[key].getLocation().x;
-            ys[i] = touches[key].getLocation().y;
+        for (var j = 0; j < touches.length; j++) {
+            ids[i] = j;
+            xs[i] = touches[j].getLocation().x;
+            ys[i] = touches[j].getLocation().y;
             ++i;
         }
         this.handleTouchesMove(i, ids, xs, ys);
@@ -577,10 +577,10 @@ cc.EGLView = cc.Class.extend(/** @lends cc.EGLView# */{
         var ys = [];
 
         var i = 0;
-        for (var key in touches) {
-            ids[i] = key;
-            xs[i] = touches[key].getLocation().x;
-            ys[i] = touches[key].getLocation().y;
+        for (var j = 0; j < touches.length; j++) {
+            ids[i] = j;
+            xs[i] = touches[j].getLocation().x;
+            ys[i] = touches[j].getLocation().y;
             ++i;
         }
         this.handleTouchesEnd(i, ids, xs, ys);
@@ -592,10 +592,10 @@ cc.EGLView = cc.Class.extend(/** @lends cc.EGLView# */{
         var ys = [];
 
         var i = 0;
-        for (var key in touches) {
-            ids[i] = key;
-            xs[i] = touches[key].getLocation().x;
-            ys[i] = touches[key].getLocation().y;
+        for (var j = 0; j < touches.length; j++) {
+            ids[i] = j;
+            xs[i] = touches[j].getLocation().x;
+            ys[i] = touches[j].getLocation().y;
             ++i;
         }
         this.handleTouchesCancel(i, ids, xs, ys);


### PR DESCRIPTION
CCEGLView.js touchesBegan, touchesEnded, touchesMoved and touchesCancelled uses for(... in...) syntax to loop through the array of touches.   This syntax explicitly loops through the properties of objects, not the elements in an array.   As a result if you add to Array.prototype,  anything you add will be iterated through when using for(...in...) syntax.    These should use "standard" for (;;) syntax.
