### PR TITLE
Prevent closure compiler from obfuscating fields in XMLHttpRequest for IE

### DIFF
--- a/cocos2d/platform/CCFileUtils.js
+++ b/cocos2d/platform/CCFileUtils.js
@@ -167,7 +167,7 @@ cc.FileUtils = cc.Class.extend({
             xhr.onreadystatechange = function (event) {
                 if (xhr.readyState == 4) {
                     if (xhr.status == 200) {
-                        var fileContents = cc._convertResponseBodyToText(xhr.responseBody);
+                        var fileContents = cc._convertResponseBodyToText(xhr["responseBody"]);
                         if (fileContents)
                             selfPointer._fileDataCache[fileUrl] = selfPointer._stringConvertToArray(fileContents);
                     }
@@ -198,9 +198,9 @@ cc.FileUtils = cc.Class.extend({
             if (req.status != 200)
                 return null;
 
-            var fileContents = cc._convertResponseBodyToText(req.responseBody);
+            var fileContents = cc._convertResponseBodyToText(req["responseBody"]);
             if (fileContents) {
-                arrayInfo = this._stringConvertToArray(req.responseText);
+                arrayInfo = this._stringConvertToArray(fileContents);
                 this._fileDataCache[fileUrl] = arrayInfo;
             }
         } else {


### PR DESCRIPTION
Google closure obfuscate field in advanced mode, and when xhr is instance of ActiveXObject("MSXML2.XMLHTTP") we got error since it have responseBody but no .Ng or something so :)

Also i think that 203 line contains typo (req.responseText instead fileContents), so fixed it too.
