### PR TITLE
Fixed Parallax position issue when adding a child

### DIFF
--- a/cocos2d/tileMap_parallax_nodes/CCParallaxNode.js
+++ b/cocos2d/tileMap_parallax_nodes/CCParallaxNode.js
@@ -153,7 +153,7 @@ cc.ParallaxNode = cc.Node.extend(/** @lends cc.ParallaxNode# */{
         obj.setChild(child);
         this._parallaxArray.push(obj);
 
-        var pos = this._position;
+        var pos = cc.p(this._position.x, this._position.y);
         pos.x = pos.x * ratio.x + offset.x;
         pos.y = pos.y * ratio.y + offset.y;
         child.setPosition(pos);


### PR DESCRIPTION
This code originally updated the ParllaxNode position while adding a child

```
var pos = this._position;
pos.x = pos.x * ratio.x + offset.x;
pos.y = pos.y * ratio.y + offset.y;
child.setPosition(pos);
```

Because Javascript always passes objects by reference, any modifications on pos updates the ParallaxNode position as well.

It should be 

```
var pos = cc.p(this._position.x, this._position.y);
```
