### PR TITLE
Fix in logical comparisons of undefined argument values against `null` for setting default argument values

### DIFF
--- a/cocos2d/base_nodes/CCNode.js
+++ b/cocos2d/base_nodes/CCNode.js
@@ -858,7 +858,7 @@ cc.NodeWebGL = cc.Class.extend(/** @lends cc.NodeWebGL# */{
      */
     removeFromParent:function (cleanup) {
         if (this._parent) {
-            if (cleanup === null)
+            if (cleanup == null)
                 cleanup = true;
             this._parent.removeChild(this, cleanup);
         }
@@ -888,7 +888,7 @@ cc.NodeWebGL = cc.Class.extend(/** @lends cc.NodeWebGL# */{
         if (this._children == null)
             return;
 
-        if (cleanup === null)
+        if (cleanup == null)
             cleanup = true;
         if (this._children.indexOf(child) > -1) {
             this._detachChild(child, cleanup);
@@ -931,7 +931,7 @@ cc.NodeWebGL = cc.Class.extend(/** @lends cc.NodeWebGL# */{
     removeAllChildren:function (cleanup) {
         // not using detachChild improves speed here
         if (this._children != null) {
-            if (cleanup === null)
+            if (cleanup == null)
                 cleanup = true;
             for (var i = 0; i < this._children.length; i++) {
                 var node = this._children[i];
@@ -2465,7 +2465,7 @@ cc.NodeCanvas = cc.Class.extend(/** @lends cc.NodeCanvas# */{
      */
     removeFromParent:function (cleanup) {
         if (this._parent) {
-            if (cleanup === null)
+            if (cleanup == null)
                 cleanup = true;
             this._parent.removeChild(this, cleanup);
         }
@@ -2495,7 +2495,7 @@ cc.NodeCanvas = cc.Class.extend(/** @lends cc.NodeCanvas# */{
         if (this._children == null)
             return;
 
-        if (cleanup === null)
+        if (cleanup == null)
             cleanup = true;
         if (this._children.indexOf(child) > -1) {
             this._detachChild(child, cleanup);
@@ -2538,7 +2538,7 @@ cc.NodeCanvas = cc.Class.extend(/** @lends cc.NodeCanvas# */{
     removeAllChildren:function (cleanup) {
         // not using detachChild improves speed here
         if (this._children != null) {
-            if (cleanup === null)
+            if (cleanup == null)
                 cleanup = true;
             for (var i = 0; i < this._children.length; i++) {
                 var node = this._children[i];

--- a/cocos2d/sprite_nodes/CCSprite.js
+++ b/cocos2d/sprite_nodes/CCSprite.js
@@ -1092,9 +1092,9 @@ cc.SpriteCanvas = cc.Node.extend(/** @lends cc.SpriteCanvas# */{
      */
     addChild:function (child, zOrder, tag) {
         cc.Assert(child != null, "Argument must be non-NULL");
-        if (zOrder === null)
+        if (zOrder == null)
             zOrder = child._zOrder;
-        if (tag === null)
+        if (tag == null)
             tag = child._tag;
 
         //cc.Node already sets isReorderChildDirty_ so this needs to be after batchNode check
@@ -2376,9 +2376,9 @@ cc.SpriteWebGL = cc.Node.extend(/** @lends cc.SpriteWebGL# */{
      */
     addChild:function (child, zOrder, tag) {
         cc.Assert(child != null, "Argument must be non-NULL");
-        if (zOrder === null)
+        if (zOrder == null)
             zOrder = child._zOrder;
-        if (tag === null)
+        if (tag == null)
             tag = child._tag;
 
         if (this._batchNode) {

--- a/cocos2d/sprite_nodes/CCSpriteBatchNode.js
+++ b/cocos2d/sprite_nodes/CCSpriteBatchNode.js
@@ -347,7 +347,7 @@ cc.SpriteBatchNodeCanvas = cc.Node.extend(/** @lends cc.SpriteBatchNodeCanvas# *
      */
     removeChild:function (child, cleanup) {
         // explicit null handling
-        if (child === null)
+        if (child == null)
             return;
 
         cc.Assert(this._children.indexOf(child) > -1, "SpriteBatchNode.addChild():sprite batch node should contain the child");
@@ -1006,7 +1006,7 @@ cc.SpriteBatchNodeWebGL = cc.Node.extend(/** @lends cc.SpriteBatchNodeWebGL# */{
      */
     removeChild:function (child, cleanup) {
         // explicit null handling
-        if (child === null)
+        if (child == null)
             return;
 
         cc.Assert(this._children.indexOf(child) > -1, "SpriteBatchNode.addChild():sprite batch node should contain the child");


### PR DESCRIPTION
Fixed comparison against few function arguments from using strict equality === against null to weak equality == as undefined values wouldn't cause the default values to be assigned as expected which could cause memory leaks as cleanup wouldnt get triggered on node removal neither for removed node nor for the child nodes when using the removeFromParent, removeChild and removeAllChildren if somebody didn't specify explicitly `true` while removing which should be default.

Also CCSprite default zOrdering and tag wouldn't be set properly for the same reason.

(And thanks guys for awesome work!)
