### PR TITLE
Fix for line height in webgl mode

### DIFF
--- a/cocos2d/label_nodes/CCLabelTTF.js
+++ b/cocos2d/label_nodes/CCLabelTTF.js
@@ -863,6 +863,7 @@ cc.LabelTTF.__getFontHeightByDiv = function(fontName, fontSize){
     var labelDiv = cc.LabelTTF.__labelHeightDiv;
     labelDiv.style.fontFamily = fontName;
     labelDiv.style.fontSize = fontSize + "px";
+    labelDiv.style.lineHeight = fontSize + "px";
     return labelDiv.clientHeight ;
 };
 


### PR DESCRIPTION
Fonts rendered weird if the body of the page has a line-height. This fix resolves the issue. I noticed this because my game had a style sheet with the line height set on the body.
