### PR TITLE
fixed #2261: Preload function failed in iOS 5.1.1

### DIFF
--- a/cocos2d/CCLoader.js
+++ b/cocos2d/CCLoader.js
@@ -225,7 +225,10 @@ cc.Loader = cc.Class.extend(/** @lends cc.Loader# */{
 
 
     _schedulePreload:function () {
-        this._interval = setInterval(this._preload.bind(this), this._animationInterval * 1000);
+        var _self = this;
+        this._interval = setInterval(function(){
+            _self._preload();
+        }, this._animationInterval * 1000);
     },
 
     _unschedulePreload:function () {


### PR DESCRIPTION
fixed #2261: Preload function failed in iOS 5.1.1
