### PR TITLE
Update CCdomNode.js

### DIFF
--- a/cocos2d/base_nodes/CCdomNode.js
+++ b/cocos2d/base_nodes/CCdomNode.js
@@ -225,9 +225,12 @@ cc.DOM.methods = /** @lends cc.DOM# */{
      */
     setParent:function (p) {
         this._parent = p;
-        p.setAnchorPoint(p.getAnchorPoint());
-        this.setNodeDirty();
-        cc.DOM.parentDOM(this);
+
+        if (p !== null) {
+            p.setAnchorPoint(p.getAnchorPoint());
+            this.setNodeDirty();
+            cc.DOM.parentDOM(this);
+        }
     },
 
     /**


### PR DESCRIPTION
When user tries to execute removeChild on EditBox - EditBox calls setParent with p === null. After that engine calls p.setAnchorPoint that leads to crash.
