### PR TITLE
The Object.defineProerty shim had a bogus check for browser implementation and this change fixes it.

### DIFF
--- a/box2d/box2d.js
+++ b/box2d/box2d.js
@@ -30,7 +30,7 @@ var Box2D = {};
 
 (function (a2j, undefined) {
 
-    if(!(Object.prototype.defineProperty instanceof Function)
+    if(!(Object.defineProperty instanceof Function)
         && Object.prototype.__defineGetter__ instanceof Function
         && Object.prototype.__defineSetter__ instanceof Function)
     {


### PR DESCRIPTION
This will be our first patch :) It's small but we'd like to get familiar with the process.

This bug is [well](http://code.google.com/p/box2dweb/issues/detail?id=41) [known](http://code.google.com/p/box2dweb/issues/detail?id=43) to be a bug in Box2D itself, but as our `cc.Class.extend` patch would require this, let's fix this first. I hope this is not adding maintenance burden on this project. 
