### PR TITLE
Fix the single page version of cocos2d-js-tests til the point that PerformanceSpriteTest can be run.

### DIFF
--- a/cocos2d/platform/CCApplication.js
+++ b/cocos2d/platform/CCApplication.js
@@ -208,7 +208,7 @@ cc.setup = function (el, width, height) {
         cc.renderContext = cc.webglContext = cc.create3DContext(cc.canvas,{'stencil': true, 'preserveDrawingBuffer': true, 'alpha': false });
     if(cc.renderContext){
         cc.renderContextType = cc.WEBGL;
-        window.gl = cc.renderContext;
+        gl = cc.renderContext; // global variable declared in CCMacro.js
         cc.drawingUtil = new cc.DrawingPrimitiveWebGL(cc.renderContext);
         cc.TextureCache.getInstance()._initializingRenderer();
     } else {

--- a/cocos2d/platform/Sys.js
+++ b/cocos2d/platform/Sys.js
@@ -42,7 +42,7 @@ try{
 */
 Object.defineProperties(sys,
 {
-	"capabilities" : {
+	capabilities : {
 		get : function(){
 			var capabilities = {"canvas":true};
 
@@ -68,7 +68,7 @@ Object.defineProperties(sys,
 		enumerable : true,
 		configurable : true
 	},
-	"os" : {
+	os : {
 		get : function() {
 			var iOS = ( navigator.userAgent.match(/(iPad|iPhone|iPod)/i) ? true : false );
 			var isAndroid = navigator.userAgent.match(/android/i) || navigator.platform.match(/android/i) ? true : false;
@@ -90,14 +90,14 @@ Object.defineProperties(sys,
 		enumerable : true,
 		configurable : true
 	},
-	"platform" : {
+	platform : {
 		get : function(){
 			return "browser";
 		},
 		enumerable : true,
 		configurable : true
 	},
-	"version" : {
+	version : {
 		get : function(){
 			return cc.ENGINE_VERSION;
 		},


### PR DESCRIPTION
This is accompanied by a [pull request](https://github.com/cocos2d/cocos2d-js-tests/pull/186) to `cocos2d-js-tests`.

This change follows some of the guideline in [Understanding the Restrictions Imposed by the Closure Compiler](https://developers.google.com/closure/compiler/docs/limitations) (the part saying **Using string names to refer to object properties** and **Referring to variables as properties of the global object** are dangerous).
