### PR TITLE
fix replaying audio effects on chrome browsers

### DIFF
--- a/CocosDenshion/SimpleAudioEngine.js
+++ b/CocosDenshion/SimpleAudioEngine.js
@@ -385,6 +385,9 @@ cc.SimpleAudioEngine = cc.AudioEngine.extend(/** @lends cc.SimpleAudioEngine# */
                 if (reclaim[i].ended) {
                     au = reclaim[i];
                     au.currentTime = 0;
+                    if (window.chrome){
+                        au.load();
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
per http://stackoverflow.com/questions/8733330/why-cant-i-play-sounds-more-than-once-using-html5-audio-tag

setting currentTime on audio effects in chrome doesn't work - need to call load on the audio instead.
