### PR TITLE
Optimize John Resig's inheritance pattern (cc.Class.extend) with advanced property initialization.

### DIFF
--- a/cocos2d/cocos2d_externs.js
+++ b/cocos2d/cocos2d_externs.js
@@ -15,6 +15,13 @@
 CSSProperties.prototype._super;
 
 /**
+ * cocos2d-html5-only. We need this becuase the cc.Class.extend's new
+ * infrastructure requires it.
+ * @type {string}
+ */
+CSSProperties.prototype.ctor;
+
+/**
  * cocos2d-html5-only.
  * @type {string}
  */

--- a/cocos2d/platform/CCClass.js
+++ b/cocos2d/platform/CCClass.js
@@ -171,7 +171,8 @@ ClassManager.getNewID=function(){
         for (var p in prototype) {
             functionBody += "this." + p + "=this." + p + ";";
         }
-        functionBody += "if(this.ctor)this.ctor.apply(this,arguments)";
+        if (prototype.ctor)
+            functionBody += "this.ctor.apply(this,arguments)";
         var Class = new Function(functionBody);
 
         Class.id = classId;


### PR DESCRIPTION
_This patch is accompanied by [four demo showcases](https://github.com/cocos2d/cocos2d-js-tests/pull/190)._

The idea behind this optimization is "stabilizing memory layout of an instance" and so inline caches can be reduced to minimum size. This is best demonstrated by **B1/B2** of the showcases.

This approach has certain advantages over patching the `this.ctor` method of certain performance-sensitive classes:
- This optimizes all classes derived from `cc.Class`.
- Duplicating codes (initial values on the prototype) is usually a bad idea.
- Patching `this.ctor` would not avoid V8's [77-property-issue](https://github.com/oupengsoftware/v8/wiki/Dictionary-mode#wiki-append-property) - when an instance created by a constructor JS function with no property assignment has more than 76 properties, it turns into "dictionary mode" in V8. See **A1/A2**. **We now build constructor JS functions with property assignments inside.**

The caveat with this patch is obvious - an object now uses _a lot_ more memory. I doubt this is a serious issue (`cc.p`, `cc.Point` and `cc.Rect` seem to be more of a memory problem like I pointed out), but if it turns out that it is, we can add a config switch.

Test results will come later, but feel free to play with this.
