### PR TITLE
Optimize cc.clone by making sure the cloned object has the same prototype chain as the original.

### DIFF
--- a/cocos2d/platform/CCCommon.js
+++ b/cocos2d/platform/CCCommon.js
@@ -31,13 +31,35 @@
  * @return {Array|object}
  */
 cc.clone = function (obj) {
-    var newObj = (obj instanceof Array) ? [] : {};
+    // Cloning is better if the new object is having the same prototype chain
+    // as the copied obj (or otherwise, the cloned object is certainly going to
+    // have a different hidden class). Play with C1/C2 of the
+    // PerformanceVirtualMachineTests suite to see how this makes an impact
+    // under extreme conditions.
+    //
+    // Object.create(Object.getPrototypeOf(obj)) doesn't work well because the
+    // prototype lacks a link to the constructor (Carakan, V8) so the new
+    // object wouldn't have the hidden class that's associated with the
+    // constructor (also, for whatever reasons, utilizing
+    // Object.create(Object.getPrototypeOf(obj)) + Object.defineProperty is even
+    // slower than the original in V8). Therefore, we call the constructor, but
+    // there is a big caveat - it is possible that the this.init() in the
+    // constructor would throw with no argument. It is also possible that a
+    // derived class forgets to set "constructor" on the prototype. We ignore
+    // these possibities for and the ultimate solution is a standardized
+    // Object.clone(<object>).
+    var newObj = new obj.constructor;
+
+    // Assuming that the constuctor above initialized all properies on obj, the
+    // following keyed assignments won't turn newObj into dictionary mode
+    // becasue they're not *appending new properties* but *assigning existing
+    // ones* (note that appending indexed properties is another story). See
+    // CCClass.js for a link to the devils when the assumption fails.
     for (var key in obj) {
         var copy = obj[key];
-        if (copy instanceof Array) {
-            newObj[key] = cc.clone(copy);
-        } else if (((typeof copy) == "object") && !(copy instanceof cc.Node)
-            && !(copy instanceof HTMLElement)) {
+        // Beware that typeof null == "object" !
+        if (((typeof copy) == "object") && copy &&
+            !(copy instanceof cc.Node) && !(copy instanceof HTMLElement)) {
             newObj[key] = cc.clone(copy);
         } else {
             newObj[key] = copy;


### PR DESCRIPTION
_This patch is accompanied by [two demo showcases](https://github.com/cocos2d/cocos2d-js-tests/pull/190)._

This patch was originally part of the [property initialization patch](https://github.com/cocos2d/cocos2d-html5/pull/1015), but it turns out that this is somewhat independent. However, this patch depends on that patch for the performance benefits.

The patched `cc.clone` would now create a "good" clone of the original:
- The cloned object is now of the type of the original's type. For example, a cloned `cc.Sprite` can now be added as a child of `cc.SpriteBatchNode` while previously an assertion fails.
- The cloned object is enough similar to the original such that it doesn't create performance nightmare because of inline cache growth. See **C1/C2** of the showcases.

I'll let you guys decide whether you want to use this instead of customized cloning functions for `cc.Action`s .

We might want to play with other cloning implementation with my **C1/C2**, such as [dankogai's](https://github.com/dankogai/js-object-clone/blob/master/object-clone.js), although I find it hard to believe that it would be more performant as it has the problem I describe in inline comments. I'll get you updated if I manage to get `Object.clone` standardized :)
