### PR TITLE
change SpriteBatchNode to only create renderTexture when it will be used

### DIFF
--- a/cocos2d/sprite_nodes/CCSpriteBatchNode.js
+++ b/cocos2d/sprite_nodes/CCSpriteBatchNode.js
@@ -373,7 +373,9 @@ cc.SpriteBatchNodeCanvas = cc.Node.extend(/** @lends cc.SpriteBatchNodeCanvas# *
             this.init(fileImage, cc.DEFAULT_SPRITE_BATCH_CAPACITY);
 
         var locCanvas = cc.canvas;
-        this._renderTexture = cc.RenderTexture.create(locCanvas.width, locCanvas.height);
+        if(this._useCache) {
+            this._renderTexture = cc.RenderTexture.create(locCanvas.width, locCanvas.height);
+        }
         this.setContentSize(cc.size(locCanvas.width, locCanvas.height));
     },
 
@@ -431,7 +433,10 @@ cc.SpriteBatchNodeCanvas = cc.Node.extend(/** @lends cc.SpriteBatchNodeCanvas# *
         if (!size)
             return;
         cc.Node.prototype.setContentSize.call(this, size);
-        this._renderTexture.setContentSize(size);
+        var locRenderTexture = this._renderTexture;
+        if(locRenderTexture) {
+            locRenderTexture.setContentSize(size);
+        }
     },
 
     /**

--- a/cocos2d/tileMap_parallax_nodes/CCTMXLayer.js
+++ b/cocos2d/tileMap_parallax_nodes/CCTMXLayer.js
@@ -73,10 +73,10 @@ cc.TMXLayer = cc.SpriteBatchNode.extend(/** @lends cc.TMXLayer# */{
      *  Constructor
      */
     ctor:function () {
+        this._useCache = true;
         cc.SpriteBatchNode.prototype.ctor.call(this);
         this._children = [];
         this._descendants = [];
-        this._useCache = true;
         this._layerSize = cc.SizeZero();
         this._mapTileSize = cc.SizeZero();
     },


### PR DESCRIPTION
When profiling for mobile web, we found that CCLabelBMFont was very slow to create (in the order of 20-50 ms per instance).  Some digging revealed that most of that time was spent creating and resizing the renderTexture.

As that texture is only actually used by CCTMXLayer, I switched around the code to only create the renderTexture when it will actually be used.
