### PR TITLE
Fixed #2550 Fixed TableView's bug that contentSize is wrong when changing datasource

### DIFF
--- a/extensions/GUI/CCScrollView/CCTableView.js
+++ b/extensions/GUI/CCScrollView/CCTableView.js
@@ -376,6 +376,7 @@ cc.TableView = cc.ScrollView.extend({
      * reloads data from data source.  the view will be refreshed.
      */
     reloadData:function () {
+        this._oldDirection = cc.SCROLLVIEW_DIRECTION_NONE;
         var locCellsUsed = this._cellsUsed;
         for (var i = 0; i < locCellsUsed.count(); i++) {
             var cell = locCellsUsed.objectAtIndex(i);


### PR DESCRIPTION
When call reloadData ,the value of this._oldDirection is not equal cc.SCROLLVIEW_DIRECTION_NONE  ,that  setContentOffset can not be called.
