### PR TITLE
Improve performance cost when creating lots of CCLabelTTF

### DIFF
--- a/cocos2d/label_nodes/CCLabelTTF.js
+++ b/cocos2d/label_nodes/CCLabelTTF.js
@@ -1432,11 +1432,17 @@ cc.LabelTTF.__labelHeightDiv.style.lineHeight = "normal";
 document.body.appendChild(cc.LabelTTF.__labelHeightDiv);
 
 cc.LabelTTF.__getFontHeightByDiv = function(fontName, fontSize){
+    var clientHeight = cc.LabelTTF.__fontHeightCache[fontName + "." + fontSize];
+    if (clientHeight > 0) return clientHeight;
     var labelDiv = cc.LabelTTF.__labelHeightDiv;
     labelDiv.style.fontFamily = fontName;
     labelDiv.style.fontSize = fontSize + "px";
-    return labelDiv.clientHeight ;
+    clientHeight = labelDiv.clientHeight ;
+    cc.LabelTTF.__fontHeightCache[fontName + "." + fontSize] = clientHeight;
+    return clientHeight;
 };
+
+cc.LabelTTF.__fontHeightCache = {};
 
 
 


### PR DESCRIPTION
When Developer  creating lots of CCLabelTTF , cc.LabelTTF.__getFontHeightByDiv method will be called repeated with same parameter and calculate the same result with a hot-spot method such as this 

```
var labelDiv = cc.LabelTTF.__labelHeightDiv;
labelDiv.style.fontFamily = fontName;
labelDiv.style.fontSize = fontSize + "px";
return labelDiv.clientHeight; // hot-spot
```

I add  a global variable called cc.LabelTTF.__fontHeightCache to cache cc.LabelTTF.__getFontHeightByDiv 's result to improve performance.
