### PR TITLE
fixed SpriteFrame.initWithTextureFilename converted (pixel-based) rect t...

### DIFF
--- a/cocos2d/sprite_nodes/CCSpriteFrame.js
+++ b/cocos2d/sprite_nodes/CCSpriteFrame.js
@@ -242,8 +242,7 @@ cc.SpriteFrame = cc.Class.extend(/** @lends cc.SpriteFrame# */{
          It is assumed that the frame was not trimmed.
          */
             case 2:
-                var rectInPixels = cc.RECT_POINTS_TO_PIXELS(rect);
-                return this.initWithTexture(texture, rectInPixels, false, cc.PointZero(), rectInPixels.size);
+                return this.initWithTexture(texture, rect, false, cc.PointZero(), rect.size);
                 break;
 
         /** Initializes a cc.SpriteFrame with a texture, rect, rotated, offset and originalSize in pixels.


### PR DESCRIPTION
If there is any additional work required to resolve this, I'd be happy to help.

Fixes #1083.

UnitTest for verification:

``` javascript
var SpriteFrameClone = UnitTestBase.extend({
    _title:"SpriteFrame cloning",
    _subtitle:"Cloning does not change the rect property",

    ctor:function () {
        this._super();
        this.runTest();
    },

    runTest:function () {
        this._super();

        var oldContentScaleFactor = cc.CONTENT_SCALE_FACTOR();
        cc.Director.getInstance().setContentScaleFactor(2.0);

        var rect = new cc.Rect(50, 60, 70, 80);
        this.original = cc.SpriteFrame.create(undefined, rect, undefined, undefined, undefined);
        this.aClone = this.original.clone();
        cc.Director.getInstance().setContentScaleFactor(oldContentScaleFactor);

        if (this.original.getRect().x != this.aClone.getRect().x ||
            this.original.getRect().y != this.aClone.getRect().y ||
            this.original.getRect().width != this.aClone.getRect().width ||
            this.original.getRect().height != this.aClone.getRect().height) {
          throw "clone() fail";
        }
    },
    //
    // Automation
    //
    testDuration:0.5,
    getExpectedResult:function () {
        var ret = {"isEqual":"yes"};
        return JSON.stringify(ret);
    },
    getCurrentResult:function () {
        this.runTest();
        var xEquals = this.original.getRect().x == this.aClone.getRect().x;
        var yEquals = this.original.getRect().y == this.aClone.getRect().y;
        var widthEquals = this.original.getRect().width == this.aClone.getRect().width;
        var heightEquals = this.original.getRect().height == this.aClone.getRect().height;

        var ret = {"isEqual": xEquals && yEquals && widthEquals && heightEquals ? "yes" : "no"};
        return JSON.stringify(ret);
    }
});

```
