### PR TITLE
fixed #1089 fixed a bug of cc.LayerColorCanvas that respecting incorrect opacity passed into init method

### DIFF
--- a/cocos2d/layers_scenes_transitions_nodes/CCLayer.js
+++ b/cocos2d/layers_scenes_transitions_nodes/CCLayer.js
@@ -828,7 +828,9 @@ cc.LayerColorCanvas = cc.LayerRGBA.extend(/** @lends cc.LayerColorCanvas# */{
         this._realColor.g = color.g;
         this._realColor.b = color.b;
 
-        this._opacity = color.a;
+        this._displayedOpacity = color.a;
+        this._realOpacity = color.a;
+
         this.setContentSize(cc.size(width, height));
         this._updateColor();
         return true;


### PR DESCRIPTION
fixed a bug of cc.LayerColorCanvas that respecting incorrect opacity passed into init method
