### PR TITLE
fix crash when BrowserTypes match nothing from navigator.userAgent .

### DIFF
--- a/cocos2d/platform/miniFramework.js
+++ b/cocos2d/platform/miniFramework.js
@@ -59,7 +59,7 @@ cc.Browser = {};
     cc.Browser.isMobile = (cc.Browser.ua.indexOf('mobile') != -1 || cc.Browser.ua.indexOf('android') != -1);
     cc.Browser.type = (function () {
         var browserTypes = cc.Browser.ua.match(/micromessenger|qqbrowser|mqqbrowser|ucbrowser|360browser|baidubrowser|maxthon|ie|opera|firefox/) || cc.Browser.ua.match(/chrome|safari/);
-        if (browserTypes.length > 0) {
+        if (browserTypes && browserTypes.length > 0) {
             var el = browserTypes[0];
             if (el == 'micromessenger') {
                 return 'wechat';


### PR DESCRIPTION
When BrowserTypes match nothing from navigator.userAgent such as open a webview from AdobeAIR runtimes , the userAgent is

```
mozilla/5.0 (macintosh; u; intel mac os x; zh-hans) applewebkit/533.19.4 (khtml, like gecko) adobeair/3.8 '  
```

now the browserType is null and will crash on 

```
if ( browserTypes.length > 0 ) {   //browserTypes = null
```
