### PR TITLE
fix for simple audio engine loading and playing issue 

### DIFF
--- a/CocosDenshion/SimpleAudioEngine.js
+++ b/CocosDenshion/SimpleAudioEngine.js
@@ -195,8 +195,9 @@ cc.SimpleAudioEngine = cc.AudioEngine.extend(/** @lends cc.SimpleAudioEngine# */
                 cc.Loader.getInstance().onResLoaded();
             }
         }
-
-        //cc.Loader.getInstance().onResLoaded();
+        else {
+            cc.Loader.getInstance().onResLoaded();
+        }
     },
 
     /**
@@ -208,6 +209,9 @@ cc.SimpleAudioEngine = cc.AudioEngine.extend(/** @lends cc.SimpleAudioEngine# */
      * cc.AudioEngine.getInstance().playMusic(path, false);
      */
     playMusic:function (path, loop) {
+        if (!this._soundEnable)
+            return;
+
         var keyname = this._getPathWithoutExt(path);
         var extName = this._getExtFromFullPath(path);
         var au;
@@ -370,6 +374,9 @@ cc.SimpleAudioEngine = cc.AudioEngine.extend(/** @lends cc.SimpleAudioEngine# */
      * var soundId = cc.AudioEngine.getInstance().playEffect(path);
      */
     playEffect:function (path, loop) {
+        if (!this._soundEnable)
+            return;
+
         var keyname = this._getPathWithoutExt(path), actExt;
         if (this._soundList.hasOwnProperty(keyname)) {
             actExt = this._soundList[keyname].ext;


### PR DESCRIPTION
on browser that doesn't support audio tag, the audio resource loading logic is wrong and can't finish loading due to can't receive onResLoad() message.
also, after fixing issue above, on this browser, the Audio object doesn't exist, so "new Audio()" will fail in playMusic() and playEffect()
