### PR TITLE
if the browser doesn't support canvas,I think what i modify is better

### DIFF
--- a/HelloHTML5World/cocos2d.js
+++ b/HelloHTML5World/cocos2d.js
@@ -51,7 +51,7 @@
         var p = d.getElementById(c.tag).parentNode;
         p.style.background = 'none';
         p.style.border = 'none';
-        p.insertBefore(s);
+        p.insertBefore(s,d.getElementById(c.tag));
 
         d.body.style.background = '#ffffff';
         return;

--- a/template/cocos2d.js
+++ b/template/cocos2d.js
@@ -51,7 +51,7 @@
         var p = d.getElementById(c.tag).parentNode;
         p.style.background = 'none';
         p.style.border = 'none';
-        p.insertBefore(s);
+        p.insertBefore(s,d.getElementById(c.tag));
 
         d.body.style.background = '#ffffff';
         return;


### PR DESCRIPTION
```
p.insertBefore(s);
```

the above code  is similar to

```
p.appendChild(s);
```

but the canvas is also full screen, when the browser doesn't support canvas, we can't see the message, because the `Cocos2dGameContainer` div has the style `overflow: hidden`.

so, we should modify the code: 

```
p.insertBefore(s,d.getElementById(c.tag));
```

I think it's better!
