### PR TITLE
mustUpdateTexture documentation

### DIFF
--- a/cocos2d/label_nodes/CCLabelTTF.js
+++ b/cocos2d/label_nodes/CCLabelTTF.js
@@ -289,7 +289,7 @@ cc.LabelTTF = cc.Sprite.extend(/** @lends cc.LabelTTF# */{
      * @param {cc.Size} shadowOffset
      * @param {Number} shadowOpacity
      * @param {Number} shadowBlur
-     * @param {Boolean} [mustUpdateTexture=false]
+     * @param {Boolean} [mustUpdateTexture=false] This parameter is not used. It's kept for cocos2d-x JSB compatibility
      */
     enableShadow:function(shadowOffset, shadowOpacity, shadowBlur, mustUpdateTexture){
         if (false === this._shadowEnabled)
@@ -312,7 +312,7 @@ cc.LabelTTF = cc.Sprite.extend(/** @lends cc.LabelTTF# */{
 
     /**
      * disable shadow rendering
-     * @param {Boolean} [mustUpdateTexture=false]
+     * @param {Boolean} [mustUpdateTexture=false] This parameter is not used. It's kept for cocos2d-x JSB compatibility
      */
     disableShadow:function(mustUpdateTexture){
         if (this._shadowEnabled) {
@@ -325,7 +325,7 @@ cc.LabelTTF = cc.Sprite.extend(/** @lends cc.LabelTTF# */{
      * enable or disable stroke
      * @param {cc.Color3B} strokeColor
      * @param {Number} strokeSize
-     * @param {Boolean} [mustUpdateTexture=false]
+     * @param {Boolean} [mustUpdateTexture=false]  This parameter is not used. It's kept for cocos2d-x JSB compatibility
      */
     enableStroke:function(strokeColor, strokeSize, mustUpdateTexture){
         if(this._strokeEnabled === false)
@@ -345,7 +345,7 @@ cc.LabelTTF = cc.Sprite.extend(/** @lends cc.LabelTTF# */{
 
     /**
      * disable stroke
-     * @param {Boolean} [mustUpdateTexture=false]
+     * @param {Boolean} [mustUpdateTexture=false] This parameter is not used. It's kept for cocos2d-x JSB compatibility
      */
     disableStroke:function(mustUpdateTexture){
         if (this._strokeEnabled){
@@ -357,7 +357,7 @@ cc.LabelTTF = cc.Sprite.extend(/** @lends cc.LabelTTF# */{
     /**
      * set text tinting
      * @param {cc.Color3B} tintColor
-     * @param {Boolean} [mustUpdateTexture=false]
+     * @param {Boolean} [mustUpdateTexture=false]  This parameter is not used. It's kept for cocos2d-x JSB compatibility
      */
     setFontFillColor:null,
 


### PR DESCRIPTION
Added documentation for mustUpdateTexture to note that althought it's not used in js it must be kept for jsb compatibility. As commented in #1195
