### PR TITLE
To set anchor point to 0,0 when created by loader

### DIFF
--- a/extensions/CCBReader/CCControlLoader.js
+++ b/extensions/CCBReader/CCControlLoader.js
@@ -248,7 +248,11 @@ var PROPERTY_INSETBOTTOM = "insetBottom";
 
 cc.Scale9SpriteLoader = cc.NodeLoader.extend({
     _createCCNode:function(parent,ccbReader){
-        return cc.Scale9Sprite.create();
+        var sprite = cc.Scale9Sprite.create();
+
+        sprite.setAnchorPoint(cc.p(0, 0));
+
+        return sprite;
     },
 
     onHandlePropTypeColor3:function(node, parent, propertyName, ccColor3B,ccbReader){


### PR DESCRIPTION
When anchor point is 0,0 , CocosBuilder will not output anchor point param setting request.Although the Scale9Sprite`s anchor point is default to 0, 0, but when calling function "initWithBatchNode", the anchor point will be set to 0.5, 0.5.
