### PR TITLE
Should outline even if fillcolor is fully transparent

### DIFF
--- a/cocos2d/draw_nodes/CCDrawNode.js
+++ b/cocos2d/draw_nodes/CCDrawNode.js
@@ -391,7 +391,7 @@ cc.DrawNodeWebGL = cc.Node.extend(/** @lends cc.DrawNodeWebGL# */{
             var offset = cc.v2fmult(cc.v2fadd(n1, n2), 1.0 / (cc.v2fdot(n1, n2) + 1.0));
             extrude[i] = {offset: offset, n: n2};
         }
-        var outline = (borderColor.a > 0.0 && borderWidth > 0.0);
+        var outline = (borderWidth > 0.0);
 
         var triangleCount = 3 * count -2;
         var vertexCount = 3 * triangleCount;


### PR DESCRIPTION
In Cocos2D-ios, you can draw a polygon with only a border but a transparent fillcolor. the same should be true here.
