### PR TITLE
cc.Texture2D.contentSize() for compatibility with jsbindings

### DIFF
--- a/cocos2d/textures/CCTexture2D.js
+++ b/cocos2d/textures/CCTexture2D.js
@@ -223,7 +223,7 @@ cc.Texture2DWebGL = cc.Class.extend(/** @lends cc.Texture2D# */{
      * @return {cc.Size}
      */
     contentSize:function () {
-        return this.contentSize();
+        return this.getContentSize();
     },
     
     getContentSizeInPixels:function () {


### PR DESCRIPTION
in jsbindings the function is called contentSize(), not getContentSize() - see https://raw.github.com/zynga/jsbindings/master/src/auto/jsb_cocos2d_classes.mm .
