### PR TITLE
fixed typo "becuase"

### DIFF
--- a/cocos2d/cocos2d_externs.js
+++ b/cocos2d/cocos2d_externs.js
@@ -15,7 +15,7 @@
 CSSProperties.prototype._super;
 
 /**
- * cocos2d-html5-only. We need this becuase the cc.Class.extend's new
+ * cocos2d-html5-only. We need this because the cc.Class.extend's new
  * infrastructure requires it.
  * @type {string}
  */


### PR DESCRIPTION
In cocos2d_externs.js there was typo.

Issue for this pull request: http://www.cocos2d-x.org/issues/3292
