### PR TITLE
Refactor CCTween's init method

### DIFF
--- a/extensions/CocoStudio/Armature/animation/CCTween.js
+++ b/extensions/CocoStudio/Armature/animation/CCTween.js
@@ -68,7 +68,8 @@ ccs.Tween = ccs.ProcessBase.extend(/** @lends ccs.Tween# */{
         this._bone = bone;
         this._tweenData = this._bone.getTweenData();
         this._tweenData.displayIndex = -1;
-        this._animation = this._bone.getArmature() != null ? this._bone.getArmature().getAnimation() : null;
+         var armature = bone.getArmature();
+        if (armature) this._animation = armature.getAnimation();
         return true;
     },
 


### PR DESCRIPTION
There are two reason to refactor CCTween's init method .
1. It will improve a little performance because of reducing duplicate method call .
2. the before code with JSCompiler will crash in some browser ( such as 360 browser base on chromium) , it seems like a browser's bug
