### PR TITLE
always go through glBindTexture2D to ensure consistent cache

### DIFF
--- a/cocos2d/label_nodes/CCLabelTTF.js
+++ b/cocos2d/label_nodes/CCLabelTTF.js
@@ -798,10 +798,7 @@ cc.LabelTTF = cc.Sprite.extend(/** @lends cc.LabelTTF# */{
             this._shaderProgram.setUniformForModelViewAndProjectionMatrixWithMat4();
 
             cc.glBlendFunc(this._blendFunc.src, this._blendFunc.dst);
-            //cc.glBindTexture2D(locTexture);
-            cc._currentBoundTexture[0] = locTexture;
-            gl.activeTexture(gl.TEXTURE0);
-            gl.bindTexture(gl.TEXTURE_2D, locTexture._webTextureObj);
+            cc.glBindTexture2D(locTexture);
 
             cc.glEnableVertexAttribs(cc.VERTEX_ATTRIB_FLAG_POSCOLORTEX);
 

--- a/cocos2d/textures/CCTexture2D.js
+++ b/cocos2d/textures/CCTexture2D.js
@@ -318,7 +318,7 @@ cc.Texture2DWebGL = cc.Class.extend(/** @lends cc.Texture2D# */{
         }
 
         this._webTextureObj = gl.createTexture();
-        gl.bindTexture(gl.TEXTURE_2D, this._webTextureObj);
+        cc.glBindTexture2D(this);
 
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
@@ -509,7 +509,7 @@ cc.Texture2DWebGL = cc.Class.extend(/** @lends cc.Texture2D# */{
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 
         this.setShaderProgram(cc.ShaderCache.getInstance().programForKey(cc.SHADER_POSITION_TEXTURE));
-        gl.bindTexture(gl.TEXTURE_2D, null);
+        cc.glBindTexture2D(null);
 
         var pixelsWide = this._htmlElementObj.width;
         var pixelsHigh = this._htmlElementObj.height;


### PR DESCRIPTION
I had a rare bug in my program where a texture wasn't generated, with the error "texImage2d: no texture". I disabled the state cache and the bug disappeared. I re-enabled it and tracked it down - the modifications in CCTexture2D.js fixed the bug. I also changed CCLabelTTF.js for consistency. Unfortunately I don't have a [SSCCE](http://sscce.org/) showing the bug but hopefully the logic of it makes enough sense on its own.
