### PR TITLE
Fix a bug on Privacy Option

### DIFF
--- a/cocos2d/core/platform/Sys.js
+++ b/cocos2d/core/platform/Sys.js
@@ -29,10 +29,12 @@ var sys = sys || {};
 */
 try{
 	sys.localStorage = window.localStorage;
+	window.localStorage.setItem("storage", "");
+	window.localStorage.removeItem("storage");
 
 }catch(e){
 
-	if( e.name === "SECURITY_ERR" ) {
+	if( e.name === "SECURITY_ERR" || e.name === "QuotaExceededError" ) {
 		cc.log("Warning: localStorage isn't enabled. Please confirm browser cookie or privacy option");
 	}
 	sys.localStorage = function(){};


### PR DESCRIPTION
Fix a bug that LocalStorage in privacy option can not catch the exception . My solution depends on http://stackoverflow.com/questions/14555347/html5-localstorage-error-with-safari-quota-exceeded-err-dom-exception-22-an
