### PR TITLE
Fix a crash when browser in Privacy Option

### DIFF
--- a/cocos2d/core/platform/Sys.js
+++ b/cocos2d/core/platform/Sys.js
@@ -35,7 +35,7 @@ try{
 }catch(e){
 
 	if( e.name === "SECURITY_ERR" || e.name === "QuotaExceededError" ) {
-		cc.log("Warning: localStorage isn't enabled. Please confirm browser cookie or privacy option");
+		console.log("Warning: localStorage isn't enabled. Please confirm browser cookie or privacy option");
 	}
 	sys.localStorage = function(){};
 }


### PR DESCRIPTION
Because of cocos2d-html5 require "CCCommon.js" after "Sys.js" , cc.log in Sys.js will be crashed . I replace it with console.log
