### PR TITLE
Refactor CCArmature's nodeToParentTransform

### DIFF
--- a/extensions/CocoStudio/Armature/CCArmature.js
+++ b/extensions/CocoStudio/Armature/CCArmature.js
@@ -293,11 +293,10 @@ ccs.Armature = ccs.NodeRGBA.extend(/** @lends ccs.Armature# */{
         this._armatureTransformDirty = false;
     },
 
-    nodeToParentTransform:function () {
-        return cc.Browser.supportWebGL ? this.nodeToParentTransformWEBGL() : this.nodeToParentTransformCanvas();
-    },
 
-    nodeToParentTransformWEBGL:function () {
+    nodeToParentTransform: null,
+
+    _nodeToParentTransformForWebGL:function () {
         if (this._transformDirty) {
             this._armatureTransformDirty = true;
             // Translate values
@@ -362,7 +361,7 @@ ccs.Armature = ccs.NodeRGBA.extend(/** @lends ccs.Armature# */{
         return this._transform;
     },
 
-    nodeToParentTransformCanvas:function () {
+    _nodeToParentTransformForCanvas:function () {
         if (!this._transform)
             this._transform = {a:1, b:0, c:0, d:1, tx:0, ty:0};
         if (this._transformDirty) {
@@ -661,6 +660,15 @@ ccs.Armature = ccs.NodeRGBA.extend(/** @lends ccs.Armature# */{
     }
 
 });
+
+
+if(cc.Browser.supportWebGL){
+    //WebGL
+    ccs.Armature.prototype.nodeToParentTransform = ccs.Armature.prototype._nodeToParentTransformForWebGL;
+}else{
+    //Canvas
+    ccs.Armature.prototype.nodeToParentTransform = ccs.Armature.prototype._nodeToParentTransformForCanvas;
+}
 
 /**
  * allocates and initializes a armature.


### PR DESCRIPTION
Refactor CCArmature's nodeToParentTransform to standard specification between WebGL / Canvas
