### PR TITLE
Optimize CCSpriteFrame's init performance 

### DIFF
--- a/cocos2d/core/sprite_nodes/CCSpriteFrame.js
+++ b/cocos2d/core/sprite_nodes/CCSpriteFrame.js
@@ -61,7 +61,6 @@ cc.SpriteFrame = cc.Class.extend(/** @lends cc.SpriteFrame# */{
         this._textureFilename = "";
         this._texture = null;
         this._textureLoaded = false;
-        this._eventListeners = [];
     },
 
     // attributes
@@ -70,6 +69,9 @@ cc.SpriteFrame = cc.Class.extend(/** @lends cc.SpriteFrame# */{
     },
 
     addLoadedEventListener:function(callback, target){
+        if (this._eventListeners == null){
+           this._eventListeners = [];
+        }
         this._eventListeners.push({eventCallback:callback, eventTarget:target});
     },
 


### PR DESCRIPTION
_eventListeners in CCSpriteFrame is only need to create when Texture is not loaded .
So I move the this._eventListeners = [] from ctor() to addEventListener();

It will reduce lots of Array init performance cost when Texture is loaded
