### PR TITLE
Optimize CCScale9Sprite updatePosition's performace

### DIFF
--- a/extensions/GUI/CCControlExtension/CCScale9Sprite.js
+++ b/extensions/GUI/CCControlExtension/CCScale9Sprite.js
@@ -137,17 +137,19 @@ cc.Scale9Sprite = cc.NodeRGBA.extend(/** @lends cc.Scale9Sprite# */{
         var size = this._contentSize;
         var locTopLeft = this._topLeft, locTopRight = this._topRight, locBottomRight = this._bottomRight;
         var locCenter = this._centre, locCenterContentSize = this._centre.getContentSize();
+        var locTopLeftContentSize = locTopLeft.getContentSize();
+        var locBottomLeftContentSize = locBottomLeft.getContentSize();
 
-        var sizableWidth = size._width - locTopLeft.getContentSize().width - locTopRight.getContentSize().width;
-        var sizableHeight = size._height - locTopLeft.getContentSize().height - locBottomRight.getContentSize().height;
+        var sizableWidth = size._width - locTopLeftContentSize.width - locTopRight.getContentSize().width;
+        var sizableHeight = size._height - locTopLeftContentSize.height - locBottomRight.getContentSize().height;
         var horizontalScale = sizableWidth / locCenterContentSize.width;
         var verticalScale = sizableHeight / locCenterContentSize.height;
         var rescaledWidth = locCenterContentSize.width * horizontalScale;
         var rescaledHeight = locCenterContentSize.height * verticalScale;
 
         var locBottomLeft = this._bottomLeft;
-        var leftWidth = locBottomLeft.getContentSize().width;
-        var bottomHeight = locBottomLeft.getContentSize().height;
+        var leftWidth = locBottomLeftContentSize.width;
+        var bottomHeight = locBottomLeftContentSize.height;
 
         if(!cc.Browser.supportWebGL) {
             //browser is in canvas mode, need to manually control rounding to prevent overlapping pixels


### PR DESCRIPTION
reduce duplicate getContentSize() in CCScale9Sprite.prototype.updatePosition();
