### PR TITLE
Optimize CCSkin updateBlendFunc Performnce

### DIFF
--- a/extensions/CocoStudio/Armature/display/CCSkin.js
+++ b/extensions/CocoStudio/Armature/display/CCSkin.js
@@ -152,7 +152,7 @@ ccs.Skin = ccs.Sprite.extend(/** @lends ccs.Skin# */{
             default:
                 break;
         }
-        this.setBlendFunc(blendFunc.src, blendFunc.dst);
+        this.setBlendFunc(blendFunc);
     }
 });
 


### PR DESCRIPTION
CCSkin.updateBlendFunc call setBlendFunc( src ,dst ) before , it will create duplicate cc.BlendFunc Object
