### PR TITLE
Fixed #3614: Avoid CCLabelTTF enter in infinite loop while character's width larger than the dimension width

### DIFF
--- a/cocos2d/core/labelTTF/CCLabelTTF.js
+++ b/cocos2d/core/labelTTF/CCLabelTTF.js
@@ -166,7 +166,8 @@ cc.LabelTTF = cc.Sprite.extend(/** @lends cc.LabelTTF# */{
             }
         }
 
-        return idfound;
+        // Avoid when idfound == 0, the process may enter in a infinite loop
+        return idfound || 1;
     },
 
     /**

--- a/cocos2d/core/platform/CCEGLView.js
+++ b/cocos2d/core/platform/CCEGLView.js
@@ -434,8 +434,8 @@ cc.EGLView = cc.Class.extend(/** @lends cc.EGLView# */{
             return;
         }
         this.setResolutionPolicy(resolutionPolicy);
-        var policy;
-        if (policy = this._resolutionPolicy)
+        var policy = this._resolutionPolicy;
+        if (policy)
             policy.preApply(this);
         else {
             cc.log("should set resolutionPolicy");


### PR DESCRIPTION
CCEGLView: better readability
