### PR TITLE
Fixed #3673: Add swallow option to cc.Layer’s setTouchEnabled function 

### DIFF
--- a/cocos2d/core/layers_nodes/CCLayer.js
+++ b/cocos2d/core/layers_nodes/CCLayer.js
@@ -46,6 +46,8 @@ cc.Layer = cc.Node.extend(/** @lends cc.Layer# */{
     _touchMode:cc.TOUCH_ALL_AT_ONCE,
     _isMouseEnabled:false,
     _mousePriority:0,
+	// This is only useful in mode TOUCH_ONE_BY_ONE
+	_swallowTouch:true,
 
     ctor: function () {
         cc.Node.prototype.ctor.call(this);
@@ -83,7 +85,7 @@ cc.Layer = cc.Node.extend(/** @lends cc.Layer# */{
         if (this._touchMode === cc.TOUCH_ALL_AT_ONCE)
             cc.registerStandardDelegate(this,this._touchPriority);
         else
-            cc.registerTargetedDelegate(this._touchPriority, true, this);
+            cc.registerTargetedDelegate(this._touchPriority, this._swallowTouch, this);
     },
 
     isMouseEnabled:function () {
@@ -136,10 +138,12 @@ cc.Layer = cc.Node.extend(/** @lends cc.Layer# */{
     /**
      * Enable touch events
      * @param {Boolean} enabled
+     * @param {Boolean} swallow: if the event listener will swallow touch after been triggered
      */
-    setTouchEnabled:function (enabled) {
+    setTouchEnabled:function (enabled, swallow) {
         if (this._isTouchEnabled !== enabled) {
             this._isTouchEnabled = enabled;
+	        this._swallowTouch = (swallow === false ? false : true);
 
             if (this._running) {
                 if (enabled) {

--- a/cocos2d/core/platform/CCEGLView.js
+++ b/cocos2d/core/platform/CCEGLView.js
@@ -597,6 +597,13 @@ cc.EGLView = cc.Class.extend(/** @lends cc.EGLView# */{
     },
 
     /**
+     * Get device pixel ratio for retina display.
+     */
+    getDevicePixelRatio: function() {
+        return this._devicePixelRatio;
+    },
+
+    /**
      * Get the real location in view
      */
     convertToLocationInView: function (tx, ty, relatedPos) {

--- a/cocos2d/touch_dispatcher/CCMouseDispatcher.js
+++ b/cocos2d/touch_dispatcher/CCMouseDispatcher.js
@@ -547,8 +547,9 @@ cc.MouseDispatcher._registerHtmlElementEvent = function (element) {
         var ty = event.pageY;
         var eglViewer = cc.EGLView.getInstance();
 
-        var mouseX = (tx - pos.left) / eglViewer.getScaleX();
-        var mouseY = (pos.height - (ty - pos.top)) / eglViewer.getScaleY();
+        var pixelRatio = eglViewer.getDevicePixelRatio();
+        var mouseX = (tx - pos.left) * pixelRatio / eglViewer.getScaleX();
+        var mouseY = (pos.height - (ty - pos.top)) * pixelRatio / eglViewer.getScaleY();
 
         var mouse = new cc.Mouse(mouseX, mouseY);
         mouse._setPrevPoint(cc.MouseDispatcher._preMousePoint.x, cc.MouseDispatcher._preMousePoint.y);


### PR DESCRIPTION
to permit not swallow touches

In addition:
- add getDevicePixelRatio API to cc.EGLView
- Fix a bug on desktop with the touch move event under retina display
