### PR TITLE
Deep-copy verts in drawPoly for consistency

### DIFF
--- a/cocos2d/shape_nodes/CCDrawNode.js
+++ b/cocos2d/shape_nodes/CCDrawNode.js
@@ -377,16 +377,17 @@ cc.DrawNodeCanvas = cc.Node.extend(/** @lends cc.DrawNodeCanvas# */{
     },
 
     /**
-     * draw a polygon with a fill color and line color
+     * draw a polygon with a fill color and line color without copying the vertex list
      * @param {Array} verts
      * @param {cc.Color4F} fillColor
      * @param {Number} lineWidth
      * @param {cc.Color4F} color
      */
-    drawPoly: function (verts, fillColor, lineWidth, color) {
+    drawPoly_: function (verts, fillColor, lineWidth, color) {
         lineWidth = lineWidth || this._lineWidth;
         color = color || this.getDrawColor();
         var element = new cc._DrawNodeElement(cc.DrawNode.TYPE_POLY);
+        
         element.verts = verts;
         element.fillColor = fillColor;
         element.lineWidth = lineWidth;
@@ -398,6 +399,21 @@ cc.DrawNodeCanvas = cc.Node.extend(/** @lends cc.DrawNodeCanvas# */{
             element.isFill = true;
         }
         this._buffer.push(element);
+    },
+    
+    /**
+     * draw a polygon with a fill color and line color, copying the vertex list
+     * @param {Array} verts
+     * @param {cc.Color4F} fillColor
+     * @param {Number} lineWidth
+     * @param {cc.Color4F} color
+     */
+    drawPoly: function (verts, fillColor, lineWidth, color) {
+        var vertsCopy = [];
+        for (var i=0; i < verts.length; i++) {
+            vertsCopy.push(cc.p(verts[i].x, verts[i].y));
+        }
+        return this.drawPoly_(vertsCopy, fillColor, lineWidth, color);     
     },
 
     draw: function (ctx) {


### PR DESCRIPTION
The WebGL .drawPoly copies the verts parameter in the process of using it internally. I suspect the JSB version does too(?). In any case, I make use of this functionality to optimize a drawing function by always re-using the same set of points, instead of computing a new set each time. This breaks when using the canvas mode. To restore compatibility I propose the canvas version also copies the vertices.

I've also added a drawPoly_ which _doesn't_ copy the vertex list - the old behavior - if efficiency is desired. This is parallel to how cc._p re-uses the same point in JSB.

One alternative would be for my code to check whether it's using the canvas version and, if so, to make a copy myself - this is not as neat as the library being consistent, though.
