### PR TITLE
Fix legacy Function.prototype.bind support

### DIFF
--- a/cocos2d/core/platform/CCClass.js
+++ b/cocos2d/core/platform/CCClass.js
@@ -183,9 +183,9 @@ ClassManager.compileSuper.ClassManager = ClassManager;
 
     Function.prototype.bind = Function.prototype.bind || function (bind) {
         var self = this;
+        var args = Array.prototype.slice.call(arguments, 1);
         return function () {
-            var args = Array.prototype.slice.call(arguments);
-            return self.apply(bind || null, args);
+            return self.apply(bind || null, args.concat(Array.prototype.slice.call(arguments)));
         };
     };
 


### PR DESCRIPTION
The current legacy support was throwing errors on some mobile devices (specifically an HTC Sense running Android 2.3.4).

The value of args should be determined by the arguments passed to bind, not to the bound function. Several places throughout the codebase bind is used in this manner, so the legacy function should support it.
