### PR TITLE
Issue #4277 : Add `bootFile` into `moduleConfig.json` to support `cocos2...

### DIFF
--- a/moduleConfig.json
+++ b/moduleConfig.json
@@ -338,5 +338,6 @@
             "external/chipmunk/chipmunk.js"
         ],
         "external" : ["box2d", "chipmunk"]
-    }
+    },
+    "bootFile" : "CCBoot.js"
 }


### PR DESCRIPTION
Issue #4277 : Add `bootFile` into `moduleConfig.json` to support `cocos2d-console` to generate the js project.
