### PR TITLE
Fix: Batch nodes not reordering after setZOrder.

### DIFF
--- a/cocos2d/core/base_nodes/CCNode.js
+++ b/cocos2d/core/base_nodes/CCNode.js
@@ -355,9 +355,11 @@ cc.Node = cc.Class.extend(/** @lends cc.Node# */{
      * @param {Number} z Z order of this node.
      */
     setZOrder:function (z) {
-        this._setZOrder(z);
+        // ZOrder is set on parent's reorderChild.
         if (this._parent)
             this._parent.reorderChild(this, z);
+        else
+            this._setZOrder(z);
     },
 
     /**


### PR DESCRIPTION
Fixing bug spoted on:
http://www.cocos2d-x.org/forums/6/topics/27230?r=29086#message-29086

On cc.SpriteBatchNode.reorderChild (on cc.ParticleBatchNode also), which is called form cc.Node.setZOrder, new zorder is compared to child's zorder, but child's zorder is already set to the new value. This effectively prevents reordering from happening on batch nodes.
