### PR TITLE
Sync cc.LabelBMFont to v3.0

### DIFF
--- a/cocos2d/labels/CCLabelBMFont.js
+++ b/cocos2d/labels/CCLabelBMFont.js
@@ -629,7 +629,9 @@ cc.LabelBMFont = cc.SpriteBatchNode.extend(/** @lends cc.LabelBMFont# */{
                     start_line = false;
                     startOfWord = -1;
                     startOfLine = -1;
-                    i+= justSkipped;
+                    //i+= justSkipped;
+                    j--;
+                    skip -= justSkipped;
                     line++;
 
                     if (i >= stringLength)
@@ -733,6 +735,11 @@ cc.LabelBMFont = cc.SpriteBatchNode.extend(/** @lends cc.LabelBMFont# */{
                 if (self._string[ctr].charCodeAt(0) == 10 || self._string[ctr].charCodeAt(0) == 0) {
                     var lineWidth = 0;
                     var line_length = last_line.length;
+                    // if last line is empty we must just increase lineNumber and work with next line
+                    if (line_length == 0) {
+                        lineNumber++;
+                        continue;
+                    }
                     var index = i + line_length - 1 + lineNumber;
                     if (index < 0) continue;
 
@@ -918,11 +925,11 @@ cc.LabelBMFont = cc.SpriteBatchNode.extend(/** @lends cc.LabelBMFont# */{
     },
 
     _getLetterPosXLeft:function (sp) {
-        return sp.getPositionX() * this._scaleX + (sp._getWidth() * this._scaleX * sp._getAnchorX());
+        return sp.getPositionX() * this._scaleX - (sp._getWidth() * this._scaleX * sp._getAnchorX());
     },
 
     _getLetterPosXRight:function (sp) {
-        return sp.getPositionX() * this._scaleX - (sp._getWidth() * this._scaleX * sp._getAnchorX());
+        return sp.getPositionX() * this._scaleX + (sp._getWidth() * this._scaleX * sp._getAnchorX());
     }
 });
 


### PR DESCRIPTION
Label Test presented some issues on BMFontMultiLine2Test:

The first letter after a line break was disappearing
Empty lines were not being shown
The functions used to calculate if a letter passed the max width were messed up
This pull request fixes them.

Commit by Bruno Assarisse
https://github.com/cocos2d/cocos2d-html5/pull/1714
