### PR TITLE
Propose adding cc.Node.position getter/setter

### DIFF
--- a/cocos2d/core/base-nodes/CCNode.js
+++ b/cocos2d/core/base-nodes/CCNode.js
@@ -2307,6 +2307,7 @@ if (cc._renderType === cc._RENDER_TYPE_WEBGL) {
 
 cc.defineGetterSetter(_p, "x", _p.getPositionX, _p.setPositionX);
 cc.defineGetterSetter(_p, "y", _p.getPositionY, _p.setPositionY);
+cc.defineGetterSetter(_p, "position", _p.getPosition, _p.setPosition);
 /** @expose */
 //_p.pos;
 //cc.defineGetterSetter(_p, "pos", _p.getPosition, _p.setPosition);


### PR DESCRIPTION
Cocos2d-HTML5 team, please consider adding `cc.Node.position` getter / setter. This makes setting a node's position via setter more "shorthand" and also allows the use of functions which return a `cc.Point`.

Consider this:

```
labelHello.x = p.x;
labelHello.y = p.y;
```

Versus this:

```
labelHello.position = p;
```

The need for a position attribute is greater when using a custom function which returns a `cc.Point`. Like this:

```
labelHello.attr({
    x: centralize(100, -50).x,
    y: centralize(100, -50).y
});
```

Versus this:

```
labelHello.attr({
    position: centralize(100, -50)
});
```

If you like the idea of adding a `position` getter / setter, please consider adding it for all other x/y and width/height properties. Like this:

```
labelHello.anchorPoint = cc.p(.5,.5);
```
