### PR TITLE
Fix getPosition() bug

### DIFF
--- a/cocos2d/core/base-nodes/CCNode.js
+++ b/cocos2d/core/base-nodes/CCNode.js
@@ -650,7 +650,7 @@ cc.Node = cc.Class.extend(/** @lends cc.Node# */{
      * @return {cc.Point} The position (x,y) of the node in OpenGL coordinates
      */
     getPosition:function () {
-        return this._position;
+        return cc.p(this._position);
     },
 
     /**


### PR DESCRIPTION
At present, calling `getPosition()` on a node returns a reference to the node's private `_position` variable. This can lead to mysterious bugs in seemingly simple code. Consider this:

```
var pos = node.getPosition();
pos.x += 5; // bad! this modifies the node's position
```

This pull request fixes the bug.
