### PR TITLE
Issue #4608: Fixed a bug that CCClippingNode.js _super is undefined

### DIFF
--- a/cocos2d/clipping-nodes/CCClippingNode.js
+++ b/cocos2d/clipping-nodes/CCClippingNode.js
@@ -323,7 +323,7 @@ cc.ClippingNode = cc.Node.extend(/** @lends cc.ClippingNode# */{
 
             context.save();
             // Draw everything first using node visit function
-            this._super(context);
+            cc.Node.prototype.visit.call(this, context);
 
             context.globalCompositeOperation = this.inverted ? "destination-out" : "destination-in";
 


### PR DESCRIPTION
Because _visitForCanvas renamed to visit, so _super is not a funciton.
