### PR TITLE
Closed #4866: Fixed a bug of cc.Scale9Sprite that its CascadeColor and CascadeOpacity are invalid.

### DIFF
--- a/extensions/gui/control-extension/CCScale9Sprite.js
+++ b/extensions/gui/control-extension/CCScale9Sprite.js
@@ -211,8 +211,6 @@ cc.Scale9Sprite = cc.NodeRGBA.extend(/** @lends cc.Scale9Sprite# */{
 
     ctor: function () {
         cc.NodeRGBA.prototype.ctor.call(this);
-        this._cascadeColorEnabled = true;
-        this._cascadeOpacityEnabled = true;
         this._spriteRect = cc.rect(0, 0, 0, 0);
         this._capInsetsInternal = cc.rect(0, 0, 0, 0);
 


### PR DESCRIPTION
Fixed a bug of cc.Scale9Sprite that its CascadeColor and CascadeOpacity are invalid.
