### PR TITLE
Fixes bug in stopMusic()

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -342,7 +342,7 @@ cc.AudioEngine = cc.Class.extend(/** @lends cc.audioEngine# */{
         if (this._musicPlayState > 0) {
             var audio = this._currMusic;
             if (!audio) return;
-            this._stopAudio(audio);
+            if (!this._stopAudio(audio)) return;
             if (releaseData) cc.loader.release(this._currMusicPath);
             this._currMusic = null;
             this._currMusicPath = null;
@@ -358,7 +358,9 @@ cc.AudioEngine = cc.Class.extend(/** @lends cc.audioEngine# */{
                 audio.pause();
                 audio.duration && (audio.currentTime = audio.duration);
             }
+            return true;
         }
+        return false;
     },
 
     /**


### PR DESCRIPTION
In Chrome, it can take a few seconds for the `ended` property of music to become `false`. Therefore if one plays music, then immediately stops the music, `_stopAudio` can silently fail and then `stopMusic` mistakenly sets `_currMusic` to `null`, which leaves the music playing and no way to stop it. The problem is compounded if this situation is repeated. There can be many music tracks playing and it slows down the browser tremendously.

This pull request fixes the bug by verifying that `_stopAudio` worked.
