### PR TITLE
Fixes WebGL Warning if Invalid Texture

### DIFF
--- a/cocos2d/core/textures/TexturesWebGL.js
+++ b/cocos2d/core/textures/TexturesWebGL.js
@@ -409,6 +409,9 @@ _tmp.WebGLTexture2D = function () {
                 if (!img) return;
                 self.initWithElement(img);
             }
+            if (!self._htmlElementObj.width || !self._htmlElementObj.height) {
+                return;
+            }
             self._isLoaded = true;
             //upload image to buffer
             var gl = cc._renderContext;


### PR DESCRIPTION
With WebGL, it's possible to get lots of warnings (and slow down the browser) if a texture is loaded that has no width or height. The following warnings will be generated:

`WebGL: INVALID_VALUE: texImage2D: no canvas CCTexture2D.js`
`[.WebGLRenderingContext]RENDER WARNING: texture bound to texture unit 0 is not renderable. It maybe non-power-of-2 and have incompatible texture filtering or is not 'texture complete' (index):1`
`WebGL: too many errors, no more errors will be reported to the console for this context.`

This pull request fixes the bug by checking the HTML element's width and height before trying to turn it into a texture.
