### PR TITLE
Fix Firefox audio bug

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -75,6 +75,7 @@ if (cc.sys._supportWebAudio) {
             var self = this;
             var sourceNode = self._sourceNode = _ctx["createBufferSource"]();
             var volumeNode = self._volumeNode;
+            offset = offset || 0;
 
             sourceNode.buffer = self._buffer;
             volumeNode["gain"].value = self._volume;


### PR DESCRIPTION
In the `_play` method, the `offset` parameter can sometimes be `undefined`. This causes the following error in Firefox which effectively disables all audio:

`TypeError: Argument 2 of AudioBufferSourceNode.start is not a finite floating-point value. sourceNode.start(0, offset);`

This pull request fixes the bug by ensuring the offset is 0 if undefined.
