### PR TITLE
fixed ClippingNode's DrawNode stencil bug on Canvas

### DIFF
--- a/cocos2d/clipping-nodes/CCClippingNode.js
+++ b/cocos2d/clipping-nodes/CCClippingNode.js
@@ -395,7 +395,6 @@ cc.ClippingNode = cc.Node.extend(/** @lends cc.ClippingNode# */{
 
     _setStencilForCanvas: function (stencil) {
         this._stencil = stencil;
-        var locEGL_ScaleX = cc.view.getScaleX(), locEGL_ScaleY = cc.view.getScaleY();
         var locContext = cc._renderContext;
         // For texture stencil, use the sprite itself
         if (stencil instanceof cc.Sprite) {
@@ -404,6 +403,7 @@ cc.ClippingNode = cc.Node.extend(/** @lends cc.ClippingNode# */{
         // For shape stencil, rewrite the draw of stencil ,only init the clip path and draw nothing.
         else if (stencil instanceof cc.DrawNode) {
             stencil.draw = function () {
+                var locEGL_ScaleX = cc.view.getScaleX(), locEGL_ScaleY = cc.view.getScaleY();
                 for (var i = 0; i < stencil._buffer.length; i++) {
                     var element = stencil._buffer[i];
                     var vertices = element.verts;


### PR DESCRIPTION
When using canvas renderer, DrawNode as ClippingNode stencil, the stencil has wrong coordinates when resizing canvas;

Steps to reproduce:
-set renderer to Canvas ("renderMode" : 1);
-enable autoresize (cc.view.resizeWithBrowserSize(true));
-create some ClippingNode with DrawNode as stencil;
-try to resize window - stencil will strangely change its position;
