### PR TITLE
Closed #4988: AddSpriteFrames is error after cc.loeader.release.

### DIFF
--- a/cocos2d/core/sprites/CCSpriteFrameCache.js
+++ b/cocos2d/core/sprites/CCSpriteFrameCache.js
@@ -194,8 +194,8 @@ cc.spriteFrameCache = /** @lends cc.spriteFrameCache# */{
         cc.assert(url, cc._LogInfos.spriteFrameCache_addSpriteFrames_2);
 
         //Is it a SpriteFrame plist?
-        var dict = cc.loader.getRes(url);
-        if(!dict["frames"])
+        var dict = this._frameConfigCache[url] || cc.loader.getRes(url);
+        if(!dict || !dict["frames"])
             return;
 
         var self = this;


### PR DESCRIPTION
Judging whether there is increased _frameConfigCache.
