### PR TITLE
Update CCArmatureAnimation.js

### DIFF
--- a/extensions/cocostudio/armature/animation/CCArmatureAnimation.js
+++ b/extensions/cocostudio/armature/animation/CCArmatureAnimation.js
@@ -251,7 +251,8 @@ ccs.ArmatureAnimation = ccs.ProcessBase.extend(/** @lends ccs.ArmatureAnimation#
                 this._loopType = ccs.ANIMATION_TYPE_TO_LOOP_FRONT;
             }
             else {
-                this._loopType = ccs.ANIMATION_TYPE_NO_LOOP;
+                //this._loopType = ccs.ANIMATION_TYPE_NO_LOOP;
+                this._loopType = ccs.ANIMATION_TYPE_TO_LOOP_FRONT;
             }
             this._durationTween = durationTween;
         }


### PR DESCRIPTION
更改了 play 方法里 不能播放一次的BUG，当 loop 为 false 时候 动画只能播放一帧，并不能完全播放完后停止，所以把 loop 判断里 loop 为假的时候 this._loopType = ccs.ANIMATION_TYPE_NO_LOOP; 改为 this._loopType = ccs.ANIMATION_TYPE_TO_LOOP_FRONT;
