### PR TITLE
Closed #5224: JSLoader module should be disabled when using single engine file in advanced mode of google closure compiler

### DIFF
--- a/cocos2d/jsloader.js
+++ b/cocos2d/jsloader.js
@@ -24,7 +24,10 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  ****************************************************************************/
-(function () {
+(function (cc) {
+    if(cc){
+        return;
+    }
     var engine = [
         // Core
         'core/platform/CCClass.js',
@@ -354,4 +357,4 @@
             d.body.appendChild(s);
         });
     }
-})();
+})(cc);


### PR DESCRIPTION
JSLoader module should be disabled when using single engine file in advanced mode of google closure compiler
