### PR TITLE
fixed bug with inverted ClippingNode with DrawNode as stencil on Canvas;

### DIFF
--- a/cocos2d/clipping-nodes/CCClippingNode.js
+++ b/cocos2d/clipping-nodes/CCClippingNode.js
@@ -311,10 +311,10 @@ cc.ClippingNode = cc.Node.extend(/** @lends cc.ClippingNode# */{
         }
 
         var context = ctx || cc._renderContext;
+        var canvas = context.canvas;
         // Composition mode, costy but support texture stencil
         if (this._cangodhelpme() || this._stencil instanceof cc.Sprite) {
             // Cache the current canvas, for later use (This is a little bit heavy, replace this solution with other walkthrough)
-            var canvas = context.canvas;
             var locCache = cc.ClippingNode._getSharedCache();
             locCache.width = canvas.width;
             locCache.height = canvas.height;
@@ -346,6 +346,19 @@ cc.ClippingNode = cc.Node.extend(/** @lends cc.ClippingNode# */{
             context.save();
             this.transform(context);
             this._stencil.visit(context);
+            if (this.inverted) {
+                context.save();
+
+                context.setTransform(1, 0, 0, 1, 0, 0);
+
+                context.moveTo(0, 0);
+                context.lineTo(0, canvas.height);
+                context.lineTo(canvas.width, canvas.height);
+                context.lineTo(canvas.width, 0);
+                context.lineTo(0, 0);
+
+                context.restore();
+            }
             context.clip();
 
             // Clip mode doesn't support recusive stencil, so once we used a clip stencil,
@@ -404,11 +417,15 @@ cc.ClippingNode = cc.Node.extend(/** @lends cc.ClippingNode# */{
         else if (stencil instanceof cc.DrawNode) {
             stencil.draw = function () {
                 var locEGL_ScaleX = cc.view.getScaleX(), locEGL_ScaleY = cc.view.getScaleY();
+                locContext.beginPath();
                 for (var i = 0; i < stencil._buffer.length; i++) {
                     var element = stencil._buffer[i];
                     var vertices = element.verts;
+
+                    cc.assert(cc.vertexListIsClockwise(vertices),
+                        "Only clockwise polygons should be used as stencil");
+
                     var firstPoint = vertices[0];
-                    locContext.beginPath();
                     locContext.moveTo(firstPoint.x * locEGL_ScaleX, -firstPoint.y * locEGL_ScaleY);
                     for (var j = 1, len = vertices.length; j < len; j++)
                         locContext.lineTo(vertices[j].x * locEGL_ScaleX, -vertices[j].y * locEGL_ScaleY);

--- a/cocos2d/core/support/CCVertex.js
+++ b/cocos2d/core/support/CCVertex.js
@@ -150,3 +150,21 @@ cc.vertexLineIntersect = function (Ax, Ay, Bx, By, Cx, Cy, Dx, Dy) {
     // Success.
     return {isSuccess:true, value:t};
 };
+
+/**
+ * returns wheter or not polygon defined by vertex list is clockwise
+ * @param {Array} verts
+ * @return {Boolean}
+ */
+cc.vertexListIsClockwise = function(verts) {
+    for (var i = 0, len = verts.length; i < len; i++) {
+        var a = verts[i];
+        var b = verts[(i + 1) % len];
+        var c = verts[(i + 2) % len];
+
+        if (cc.pCross(cc.pSub(b, a), cc.pSub(c, b)) > 0)
+            return false;
+    }
+
+    return true;
+};


### PR DESCRIPTION
_Summary:_
_setInverted(true)_ doesn't work if You're using _DrawNode_ as _stencil_ on _canvas_ renderer;

_Reproduce steps:_
-Set _renderMode_ to _canvas_
-Add _ClippingNode_
-Set _inverted_ to _true_ for _ClippingNode_
-Set _DrawNode_ as stencil;
Expected results:
everything draws outside DrawNode;
Actual results:
everything is drawn inside DrawNode;

For quick reproduce:
-set renderMode
-add these lines at the end of _MyLayer.init_ function in template

---

```
    for (var i = 0; i < 2; ++i) {
        var s = cc.size(size.width, size.height / 2);
        var white = cc.color(255, 255, 255, 255);

        var node = cc.ClippingNode.create();

        var fadeLayer = cc.LayerColor.create(white, s.width, s.height);
        node.addChild(fadeLayer);

        var stencil = cc.DrawNode.create();
        var rectangle = [
            cc.p(s.width * 0.25, s.height * 0.25),
            cc.p(s.width * 0.25, s.height * 0.75),
            cc.p(s.width * 0.75, s.height * 0.75),
            cc.p(s.width * 0.75, s.height * 0.25)
        ];
        stencil.drawPoly(rectangle, white, 1, white);
        node.setInverted(i % 2);
        node.setStencil(stencil);

        node.setPosition(0, (i % 2) * size.height / 2);
        this.addChild(node);
    }
```

---

There's a restriction in this solution: only clockwise polygons are supported;

before:
![before](https://cloud.githubusercontent.com/assets/4687396/3172771/8aaff178-ebda-11e3-82f9-02d1438bd751.png)
after:
![after](https://cloud.githubusercontent.com/assets/4687396/3172773/8e3d31ac-ebda-11e3-9c58-ecec7736cb7d.png)
