### PR TITLE
fixed cc.Skin bounding box calculation for canvas rendering

### DIFF
--- a/extensions/cocostudio/armature/display/CCSkin.js
+++ b/extensions/cocostudio/armature/display/CCSkin.js
@@ -98,12 +98,10 @@ ccs.Skin = ccs.Sprite.extend(/** @lends ccs.Skin# */{
             this._transform = cc.AffineTransformConcat(locTransform, locArmature.nodeToParentTransform());
         }
         if (cc._renderType === cc._RENDER_TYPE_CANVAS) {
-            locTransform = this._transform
+            locTransform = this._transform;
             locTransform.b *= -1;
             locTransform.c *= -1;
-            var tempB = locTransform.b;
-            locTransform.b = locTransform.c;
-            locTransform.c = tempB;
+            locTransform.b = [locTransform.c, locTransform.c = locTransform.b][0];
         }
     },
     /** returns a "local" axis aligned bounding box of the node. <br/>
@@ -113,6 +111,11 @@ ccs.Skin = ccs.Sprite.extend(/** @lends ccs.Skin# */{
     getBoundingBox: function () {
         var rect = cc.rect(0, 0, this._contentSize.width, this._contentSize.height);
         var transForm = this.nodeToParentTransform();
+        if (cc._renderType === cc._RENDER_TYPE_CANVAS) {
+            transForm.b *= -1;
+            transForm.c *= -1;
+            transForm.b = [transForm.c, transForm.c = transForm.b][0];
+        }
         return cc.RectApplyAffineTransform(rect, transForm);
     },
 


### PR DESCRIPTION
The problem was: when I insert my animation created in CocoStudioAnimation to my project it is rendered correct when I use WebGL mode, but when I use Canvas mode the root position of animation was wrong, it had been caused by bounding box calculation in CCSkin.js. The transform which is changing for canvas mode in updateArmatureTransform method mustn't be used in getBoundingBox method, this method must use original transform which I get by using the same negative transponent algorithm in the method. And also I improved this calculation algorithm to the shortest form. Now animations are being rendered in the same position for WebGL and Canvas mode.
