### PR TITLE
Closed #5613: fixed a bug of cc.Audio that it throws an error when audio's duration is infinity

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -1059,7 +1059,7 @@ cc._audioLoader._supportedAudioTypes = function () {
 cc.loader.register(["mp3", "ogg", "wav", "mp4", "m4a"], cc._audioLoader);
 
 // Initialize Audio engine singleton
-cc.audioEngine = cc.AudioEngineForSingle ? new cc.AudioEngine() : new cc.AudioEngine();
+cc.audioEngine = cc.AudioEngineForSingle ? new cc.AudioEngineForSingle() : new cc.AudioEngine();
 cc.eventManager.addCustomListener(cc.game.EVENT_HIDE, function () {
     cc.audioEngine._pausePlaying();
 });


### PR DESCRIPTION
Fixed a bug of cc.Audio that it throws an error when audio's duration is infinity
