### PR TITLE
[Fix] - Check empty string for textureData

### DIFF
--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -1608,7 +1608,7 @@ cc.ParticleSystem = cc.Node.extend(/** @lends cc.ParticleSystem# */{
                 } else {
                     var textureData = locValueForKey("textureImageData", dictionary);
 
-                    if (textureData && textureData.length == 0) {
+                    if (!str || 0 === str.length) {
                         tex = cc.textureCache.addImage(imgPath);
                         if (!tex)
                             return false;


### PR DESCRIPTION
Previous way which is used to check string is empty or null is not right because in case of string is empty the expression always false.
