### PR TITLE
[Fix] - Already add child in menuItem

### DIFF
--- a/cocos2d/menus/CCMenuItem.js
+++ b/cocos2d/menus/CCMenuItem.js
@@ -705,9 +705,9 @@ cc.MenuItemSprite = cc.MenuItem.extend(/** @lends cc.MenuItemSprite# */{
             } else if (four !== undefined && typeof three === "function") {
                 target = four;
                 callback = three;
-                disabledImage = selectedSprite;
+                disabledImage = cc.Sprite.create(selectedSprite);
             } else if (three === undefined) {
-                disabledImage = selectedSprite;
+                disabledImage = cc.Sprite.create(selectedSprite);
             }
             this.initWithNormalSprite(normalSprite, selectedSprite, disabledImage, callback, target);
         }


### PR DESCRIPTION
If we use disabledImage as reference to selectedSprite, when disabledImage was added to View it causes warning
