### PR TITLE
Issue #5771: popScene can't see ccs

### DIFF
--- a/cocos2d/core/base-nodes/CCNode.js
+++ b/cocos2d/core/base-nodes/CCNode.js
@@ -1510,9 +1510,6 @@ cc.Node = cc.Class.extend(/** @lends cc.Node# */{
         this._running = false;
         this.pause();
         this._arrayMakeObjectsPerformSelector(this._children, cc.Node.StateCallbackType.onExit);
-        if (this._componentContainer) {
-            this._componentContainer.removeAll();
-        }
     },
 
     // actions


### PR DESCRIPTION
sceneA is include a ccs. when popScene SceneA can't see the ccs again.

sceneA create code :
ctor:function(){
this._super();
var node = ccs.sceneReader.createNodeWithSceneFile(res.scene.city);
this.addChild(node);
}
