### PR TITLE
Fixed #2030: Label text bounding error

### DIFF
--- a/cocos2d/core/labelttf/CCLabelTTF.js
+++ b/cocos2d/core/labelttf/CCLabelTTF.js
@@ -192,16 +192,26 @@ cc.LabelTTF = cc.Sprite.extend(/** @lends cc.LabelTTF# */{
         if (found) return idfound;
 
         // Backward check when forward check failed
-        substr = text.substr(0, baseNb);
+        substr = text.substr(0, baseNb + 1);
         idfound = baseNb;
         while (result = reversre.exec(substr)) {
             // BUG: Not secured if check with result[0]
-            idfound = result[1].length;
-            substr = result[1];
+
+            if(substr !== result[0]){
+                idfound = result[0].length;
+                substr = result[0];
+            }else{
+                idfound = result[1].length;
+                substr = result[1];
+                //If the first is a symbol
+                if(result[2]){
+                    if(cc.LabelTTF._checkSymbol.test(result[2])){
+                        continue;
+                    }
+                }
+            }
             l = this._measure(substr);
             if (l < width) {
-                if (enre.test(result[2]))
-                    idfound++;
                 break;
             }
         }
@@ -1143,9 +1153,11 @@ cc.LabelTTF._textAlign = ["left", "center", "right"];
 cc.LabelTTF._textBaseline = ["top", "middle", "bottom"];
 
 // Class static properties for measure util
-cc.LabelTTF._checkRegEx = /(.+?)([\s\n\r\-\/\\\:]|[\u4E00-\u9FA5]|[\uFE30-\uFFA0])/;
-cc.LabelTTF._reverseCheckRegEx = /(.*)([\s\n\r\-\/\\\:]|[\u4E00-\u9FA5]|[\uFE30-\uFFA0])/;
+cc.LabelTTF._checkRegEx = /(.+?|[\s\n\r\-\/\\\:]|[\u4E00-\u9FA5\uFE30-\uFFA0\u3040-\u309F\u30A0-\u30FF\u3001])/;
+cc.LabelTTF._reverseCheckRegEx = /(.*)([\s\n\r\-\/\\\:]|[\u4E00-\u9FA5\uFE30-\uFFA0\u3040-\u309F\u30A0-\u30FF\u3001])/;
 cc.LabelTTF._checkEnRegEx = /[\s\-\/\\\:]/;
+cc.LabelTTF._checkSymbol = /[\u007e\u0021\u0040\u0023\u0024\u0025\u005e\u0026\u002a\u0028\u0029\u005f\u002b\u007b\u007d\u005b\u005d\u003a\u0026\u0071\u0075\u006f\u0074\u003b\u007c\u003b\u0026\u0023\u0033\u0039\u003b\u005c\u0026\u006c\u0074\u003b\u0026\u0067\u0074\u003b\u003f\u002c\u002e\u002f\uff01\u0040\uffe5\u2026\uff08\uff09\u2014\u002b\u3010\u3011\uff1a\u201c\u007c\uff1b\u2018\u3001\u300a\u300b\uff1f\uff0c\u3002\u3001\u000d\u000a]/;
+cc.LabelTTF._checkCharacter = /[\u4E00-\u9FA5\uFE30-\uFFA0\u3040-\u309F\u30A0-\u30FF]/;
 
 // Only support style in this format: "18px Verdana" or "18px 'Helvetica Neue'"
 cc.LabelTTF._fontStyleRE = /^(\d+)px\s+['"]?([\w\s\d]+)['"]?$/;


### PR DESCRIPTION
As you see from the screenshot above, I'm using the same label, but string wrapping is causing parts of strings to appear in different lines.

The first screenshot has 足りない、 on the second line,
but the second screenshot has 足りない、 on the first line.

Something seems to be going wrong with bounding when strings cross the boundary - this seems like a big bug that needs fixing.

Here are two test strings that might help:
バグ等に思われる物を発見したり、何らかの機能が足りない、
バグ等に思われる物を発見したり、何らかの機能が足りない、aaaaaaaaaaaaaaaaaa
