### PR TITLE
fix an unreachable bug fix: remove listeners in _toAddedListeners;

### DIFF
--- a/cocos2d/core/event-manager/CCEventManager.js
+++ b/cocos2d/core/event-manager/CCEventManager.js
@@ -777,14 +777,13 @@ cc.eventManager = /** @lends cc.eventManager# */{
             // Don't want any dangling pointers or the possibility of dealing with deleted objects..
             delete _t._nodePriorityMap[listenerType.__instanceId];
             cc.arrayRemoveObject(_t._dirtyNodes, listenerType);
-            var listeners = _t._nodeListenersMap[listenerType.__instanceId];
-            if (!listeners)
-                return;
-
-            var listenersCopy = cc.copyArray(listeners), i;
-            for (i = 0; i < listenersCopy.length; i++)
-                _t.removeListener(listenersCopy[i]);
-            listenersCopy.length = 0;
+            var listeners = _t._nodeListenersMap[listenerType.__instanceId], i;
+            if (listeners) {
+                var listenersCopy = cc.copyArray(listeners);
+                for (i = 0; i < listenersCopy.length; i++)
+                    _t.removeListener(listenersCopy[i]);
+                listenersCopy.length = 0;
+            }
 
             // Bug fix: ensure there are no references to the node in the list of listeners to be added.
             // If we find any listeners associated with the destroyed node in this list then remove them.


### PR DESCRIPTION
When I read widgets from ui.json, GUIReader builds those ui and setup touch-events and then keeps those touch-events in _toAddedListeners of cc.eventManager until using `addChild(widget);`

In some cases, I need to remove some components in the widget that is binding touch-event before `addChild()`.

But engine forget to remove their associated touch-event from _toAddedListeners.
