### PR TITLE
Issue #5816: CCScale9Sprite and CCSprite texture error

### DIFF
--- a/cocos2d/core/sprites/CCSprite.js
+++ b/cocos2d/core/sprites/CCSprite.js
@@ -1329,7 +1329,10 @@ if (cc._renderType === cc._RENDER_TYPE_CANVAS) {
                 _t._rect.width = rect.width;
                 _t._rect.height = rect.height;
             }
+            if(_t.texture)
+                _t.texture.removeLoadedEventListener(_t);
             texture.addLoadedEventListener(_t._textureLoadedCallback, _t);
+            _t.texture = texture;
             return true;
         }
 

--- a/extensions/gui/control-extension/CCScale9Sprite.js
+++ b/extensions/gui/control-extension/CCScale9Sprite.js
@@ -490,21 +490,23 @@ cc.Scale9Sprite = cc.Node.extend(/** @lends cc.Scale9Sprite# */{
         var texture = cc.textureCache.textureForKey(file);
         if (!texture) {
             texture = cc.textureCache.addImage(file);
-            var locLoaded = texture.isLoaded();
-            this._textureLoaded = locLoaded;
-            if(!locLoaded){
-                texture.addLoadedEventListener(function(sender){
-                    // the texture is rotated on Canvas render mode, so isRotated always is false.
-                    var preferredSize = this._preferredSize;
-                    preferredSize = cc.size(preferredSize.width, preferredSize.height);
-                    var size  = sender.getContentSize();
-                    this.updateWithBatchNode(this._scale9Image, cc.rect(0,0,size.width,size.height), false, this._capInsets);
-                    this.setPreferredSize(preferredSize);
-                    this._positionsAreDirty = true;
-                    this._callLoadedEventCallbacks();
-                }, this);
-            }
         }
+
+        var locLoaded = texture.isLoaded();
+        this._textureLoaded = locLoaded;
+        if(!locLoaded){
+            texture.addLoadedEventListener(function(sender){
+                // the texture is rotated on Canvas render mode, so isRotated always is false.
+                var preferredSize = this._preferredSize;
+                preferredSize = cc.size(preferredSize.width, preferredSize.height);
+                var size  = sender.getContentSize();
+                this.updateWithBatchNode(this._scale9Image, cc.rect(0,0,size.width,size.height), false, this._capInsets);
+                this.setPreferredSize(preferredSize);
+                this._positionsAreDirty = true;
+                this._callLoadedEventCallbacks();
+            }, this);
+        }
+
         return this.initWithBatchNode(cc.SpriteBatchNode.create(file, 9), rect, false, capInsets);
     },
 


### PR DESCRIPTION
1. Update failed of texture, When the resource is not loaded and reload Texture
2. Resources exist, but not loaded, the use of second elements will not be updated bug
