### PR TITLE
fix child armature setSpeedScale issue;

### DIFF
--- a/extensions/cocostudio/armature/animation/CCArmatureAnimation.js
+++ b/extensions/cocostudio/armature/animation/CCArmatureAnimation.js
@@ -181,7 +181,7 @@ ccs.ArmatureAnimation = ccs.ProcessBase.extend(/** @lends ccs.ArmatureAnimation#
             var bone = dict[key];
             bone.getTween().setProcessScale(this._processScale);
             if (bone.getChildArmature())
-                bone.getChildArmature().getAnimation().setProcessScale(this._processScale);
+                bone.getChildArmature().getAnimation().setSpeedScale(this._processScale);
         }
     },
 
@@ -252,7 +252,7 @@ ccs.ArmatureAnimation = ccs.ProcessBase.extend(/** @lends ccs.ArmatureAnimation#
                 tween.setProcessScale(this._processScale);
 
                 if (bone.getChildArmature())
-                    bone.getChildArmature().getAnimation().setProcessScale(this._processScale);
+                    bone.getChildArmature().getAnimation().setSpeedScale(this._processScale);
             } else {
                 if(!bone.isIgnoreMovementBoneData()){
                     //! this bone is not include in this movement, so hide it


### PR DESCRIPTION
When changing child-armature's speed, it should changes all its bones' speed; But ArmatureAnimation.setProcessScale() doesn't do that; We should use ArmatureAnimation.setSpeedScale() instead;

NOTICE: cocos2d-x has the same problem; 
