### PR TITLE
Fixed #2107: LoadingBar setPercent is invalid.

### DIFF
--- a/extensions/ccui/uiwidgets/UILoadingBar.js
+++ b/extensions/ccui/uiwidgets/UILoadingBar.js
@@ -248,9 +248,9 @@ ccui.LoadingBar = ccui.Widget.extend(/** @lends ccui.LoadingBar# */{
     setPercent: function (percent) {
         if (percent < 0 || percent > 100)
             return;
+        this._percent = percent;
         if (this._totalLength <= 0)
             return;
-        this._percent = percent;
         var res = this._percent / 100.0;
 
         if (this._scale9Enabled)
@@ -268,6 +268,12 @@ ccui.LoadingBar = ccui.Widget.extend(/** @lends ccui.LoadingBar# */{
                 )
             );
         }
+    },
+
+    setContentSize: function(contentSize, height){
+        ccui.Widget.prototype.setContentSize.call(this, contentSize, height);
+        var locWidth = (height === undefined) ? contentSize.width : contentSize;
+        this._totalLength = locWidth;
     },
 
     /**


### PR DESCRIPTION
1. setPercent is invalid when _scale9Enabled is true.
2. setPercent is invalid when setContentSize after setPercent
