### PR TITLE
calling super via `_super_METHOD_NAME`

### DIFF
--- a/cocos2d/actions/CCActionInstant.js
+++ b/cocos2d/actions/CCActionInstant.js
@@ -359,7 +359,7 @@ cc.FlipY = cc.ActionInstant.extend(/** @lends cc.FlipY# */{
      * @param {Number} time
      */
     update:function (time) {
-        //this._super();
+        //this._super_update();
         this.target.flippedY = this._flippedY;
     },
 
@@ -548,7 +548,7 @@ cc.CallFunc = cc.ActionInstant.extend(/** @lends cc.CallFunc# */{
      * @param {Number} time
      */
     update:function (time) {
-        //this._super(target);
+        //this._super_update(target);
         this.execute();
     },
 

--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -716,7 +716,7 @@ if (!cc.sys._supportWebAudio && cc.sys._supportMultipleAudio < 0) {
 
         _playMusic: function (audio) {
             this._stopAllEffects();
-            this._super(audio);
+            this._super__playMusic(audio);
         },
 
         resumeMusic: function () {
@@ -725,7 +725,7 @@ if (!cc.sys._supportWebAudio && cc.sys._supportMultipleAudio < 0) {
                 self._stopAllEffects();
                 self._needToResumeMusic = false;
                 self._expendTime4Music = 0;
-                self._super();
+                self._super_resumeMusic();
             }
         },
 

--- a/cocos2d/core/platform/CCClass.js
+++ b/cocos2d/core/platform/CCClass.js
@@ -114,9 +114,9 @@ var ClassManager = {
         for(var idx = 0, li = arguments.length; idx < li; ++idx) {
             var prop = arguments[idx];
             desc.value = function(){
-                console.log("`_super(..)` has been deprecated, use `_super_METHOD_NAME(..)` instead.");
                 for(name in prop){
                     if(prop[name] === this._super.caller){
+                        console.log('`this._super(..)` has been deprecated, use `this._super_' + name + '(..)` instead.');
                         return _super[name].apply(this, arguments);
                     }
                 }

--- a/cocos2d/core/platform/CCClass.js
+++ b/cocos2d/core/platform/CCClass.js
@@ -40,38 +40,6 @@ var ClassManager = {
 
     instanceId : (0|(Math.random()*998)),
 
-    compileSuper : function(func, name, id){
-        //make the func to a string
-        var str = func.toString();
-        //find parameters
-        var pstart = str.indexOf('('), pend = str.indexOf(')');
-        var params = str.substring(pstart+1, pend);
-        params = params.trim();
-
-        //find function body
-        var bstart = str.indexOf('{'), bend = str.lastIndexOf('}');
-        var str = str.substring(bstart+1, bend);
-
-        //now we have the content of the function, replace this._super
-        //find this._super
-        while(str.indexOf('this._super')!= -1)
-        {
-            var sp = str.indexOf('this._super');
-            //find the first '(' from this._super)
-            var bp = str.indexOf('(', sp);
-
-            //find if we are passing params to super
-            var bbp = str.indexOf(')', bp);
-            var superParams = str.substring(bp+1, bbp);
-            superParams = superParams.trim();
-            var coma = superParams? ',':'';
-
-            //replace this._super
-            str = str.substring(0, sp)+  'ClassManager['+id+'].'+name+'.call(this'+coma+str.substring(bp+1);
-        }
-        return Function(params, str);
-    },
-
     getNewID : function(){
         return this.id++;
     },
@@ -80,10 +48,8 @@ var ClassManager = {
         return this.instanceId++;
     }
 };
-ClassManager.compileSuper.ClassManager = ClassManager;
 
 (function () {
-    var fnTest = /\b_super\b/;
     var config = cc.game.config;
     var releaseMode = config[cc.game.CONFIG_KEY.classReleaseMode];
     if(releaseMode) {
@@ -147,33 +113,24 @@ ClassManager.compileSuper.ClassManager = ClassManager;
 
         for(var idx = 0, li = arguments.length; idx < li; ++idx) {
             var prop = arguments[idx];
+            desc.value = function(){
+                console.log("`_super(..)` has been deprecated, use `_super_METHOD_NAME(..)` instead.");
+                for(name in prop){
+                    if(prop[name] === this._super.caller){
+                        return _super[name].apply(this, arguments);
+                    }
+                }
+            };
+            Object.defineProperty(prototype, '_super', desc);
+
             for (var name in prop) {
                 var isFunc = (typeof prop[name] === "function");
-                var override = (typeof _super[name] === "function");
-                var hasSuperCall = fnTest.test(prop[name]);
-
-                if (releaseMode && isFunc && override && hasSuperCall) {
-                    desc.value = ClassManager.compileSuper(prop[name], name, classId);
-                    Object.defineProperty(prototype, name, desc);
-                } else if (isFunc && override && hasSuperCall) {
-                    desc.value = (function (name, fn) {
-                        return function () {
-                            var tmp = this._super;
-
-                            // Add a new ._super() method that is the same method
-                            // but on the super-Class
-                            this._super = _super[name];
-
-                            // The method only need to be bound temporarily, so we
-                            // remove it when we're done executing
-                            var ret = fn.apply(this, arguments);
-                            this._super = tmp;
-
-                            return ret;
-                        };
-                    })(name, prop[name]);
-                    Object.defineProperty(prototype, name, desc);
-                } else if (isFunc) {
+                var overriden = (typeof _super[name] === "function");
+                if (isFunc) {
+                    if(overriden){
+                        desc.value = _super[name];
+                        Object.defineProperty(prototype, '_super_' + name, desc);
+                    }
                     desc.value = prop[name];
                     Object.defineProperty(prototype, name, desc);
                 } else {

--- a/cocos2d/core/platform/CCEGLView.js
+++ b/cocos2d/core/platform/CCEGLView.js
@@ -790,24 +790,24 @@ cc.ContentStrategy = cc.Class.extend(/** @lends cc.ContentStrategy# */{
 
     var EqualToWindow = EqualToFrame.extend({
         preApply: function (view) {
-	        this._super(view);
+	        this._super_preApply(view);
             view._frame = document.documentElement;
         },
 
         apply: function (view) {
-            this._super(view);
+            this._super_apply(view);
             this._fixContainer();
         }
     });
 
     var ProportionalToWindow = ProportionalToFrame.extend({
         preApply: function (view) {
-	        this._super(view);
+	        this._super_preApply(view);
             view._frame = document.documentElement;
         },
 
         apply: function (view, designedResolution) {
-            this._super(view, designedResolution);
+            this._super_apply(view, designedResolution);
             this._fixContainer();
         }
     });

--- a/cocos2d/physics/CCPhysicsSprite.js
+++ b/cocos2d/physics/CCPhysicsSprite.js
@@ -145,7 +145,7 @@
             else {
                 cc.log("PhysicsSprite body or PTIMRatio was not set");
             }
-            this._super();
+            this._super_visit();
         },
         setIgnoreBodyRotation: function(b) {
             this._ignoreBodyRotation = b;

--- a/cocos2d/text-input/CCTextFieldTTF.js
+++ b/cocos2d/text-input/CCTextFieldTTF.js
@@ -265,7 +265,7 @@ cc.TextFieldTTF = cc.LabelTTF.extend(/** @lends cc.TextFieldTTF# */{
     },
 
     visit: function(ctx){
-        this._super(ctx);
+        this._super_visit(ctx);
     },
 
     //////////////////////////////////////////////////////////////////////////

--- a/extensions/gui/scrollview/CCScrollView.js
+++ b/extensions/gui/scrollview/CCScrollView.js
@@ -314,7 +314,7 @@ cc.ScrollView = cc.Layer.extend(/** @lends cc.ScrollView# */{
         for (var i = 0; i < selChildren.length; i++) {
             selChildren[i].pause();
         }
-        this._super();
+        this._super_pause();
     },
 
     /**
@@ -326,7 +326,7 @@ cc.ScrollView = cc.Layer.extend(/** @lends cc.ScrollView# */{
             selChildren[i].resume();
         }
         this._container.resume();
-        this._super();
+        this._super_resume();
     },
 
     isDragging:function () {

--- a/extensions/spine/CCSkeletonAnimation.js
+++ b/extensions/spine/CCSkeletonAnimation.js
@@ -144,7 +144,7 @@ sp.SkeletonAnimation = sp.Skeleton.extend({
         atlasFile && this.initWithArgs(skeletonDataFile, atlasFile, scale);
     },
     init: function () {
-        this._super();
+        this._super_init();
         this.setAnimationStateData(new spine.AnimationStateData(this._skeleton.data));
     },
     setAnimationStateData: function (stateData) {
@@ -188,7 +188,7 @@ sp.SkeletonAnimation = sp.Skeleton.extend({
         this._state.clearTrack(trackIndex);
     },
     update: function (dt) {
-        this._super(dt);
+        this._super_update(dt);
 
         dt *= this._timeScale;
         this._state.update(dt);

--- a/template/src/myApp.js
+++ b/template/src/myApp.js
@@ -6,7 +6,7 @@ var MyLayer = cc.Layer.extend({
 
         //////////////////////////////
         // 1. super init first
-        this._super();
+        this._super_init();
 
         /////////////////////////////
         // 2. add a menu item with "X" image, which is clicked to quit the program
@@ -49,7 +49,7 @@ var MyLayer = cc.Layer.extend({
 
 var MyScene = cc.Scene.extend({
     onEnter:function () {
-        this._super();
+        this._super_onEnter();
         var layer = new MyLayer();
         this.addChild(layer);
         layer.init();


### PR DESCRIPTION
Hi, this is a proposal patch to fix #1266, 

It's trying to bind all overridden parent functions as `_super_METHOD_NAME`. This syntax looks a little ugly but it seems we have to use this string-concatenation approach. Because:

* it's hard to bind 2-depth property into prototype
* if we let the syntax be `this._super.method_name`. Then the method should be called on `this._super` instead of `this`. (Although we can user `function.bind` trick, but we shouldn't, because it is the JavaScript convention.)

<del>This patch introduced a little incompatibility:</del>

* <del>if any user code tried to extend framework classes, AND used the `this._super(...)` syntax. It would yield a deprecation error.</del>

update: 

* I used [`Function.caller`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/caller) to polyfill the `_super` method, any existing user code (using `this._super` syntax) will still work.