### PR TITLE
fixed CCProgressTimer draw on canvas with colorized sprite

### DIFF
--- a/cocos2d/progress-timer/CCProgressTimer.js
+++ b/cocos2d/progress-timer/CCProgressTimer.js
@@ -469,7 +469,7 @@ cc.ProgressTimer = cc.Node.extend(/** @lends cc.ProgressTimer# */{
         //draw sprite
         if (locSprite._texture && locTextureCoord.validRect) {
             var image = locSprite._texture.getHtmlElementObj();
-            if (this._colorized) {
+            if (locSprite._colorized) {
                 context.drawImage(image,
                     0, 0, locTextureCoord.width, locTextureCoord.height,
                     flipXOffset, flipYOffset, locDrawSizeCanvas.width, locDrawSizeCanvas.height);


### PR DESCRIPTION
`CCProgressTimer.setColor` sometimes removes sprite on canvas renderer. This happens due to wrong check in draw method. `this._colorized` is always false, we need to check `locSprite._colorized`
