### PR TITLE
Detect  the mouse in the touch screen tablet

### DIFF
--- a/CCBoot.js
+++ b/CCBoot.js
@@ -1422,7 +1422,7 @@ cc._initSys = function (config, CONFIG_KEY) {
         capabilities["opengl"] = true;
     if (docEle['ontouchstart'] !== undefined || nav.msPointerEnabled)
         capabilities["touches"] = true;
-    else if (docEle['onmouseup'] !== undefined)
+    if (docEle['onmouseup'] !== undefined)
         capabilities["mouse"] = true;
     if (docEle['onkeyup'] !== undefined)
         capabilities["keyboard"] = true;


### PR DESCRIPTION
On a touch screen tablet(eg. Surface Pro) when using the web browser will be unable to detect the mouse, and when using the touch screen, the system will automatically block mouse. So do not have to deliberately blocked mouse.
