### PR TITLE
fixed not working frameRate setting

### DIFF
--- a/CCBoot.js
+++ b/CCBoot.js
@@ -1793,7 +1793,7 @@ cc.game = {
      * @private
      */
     _getTime: function() {
-        return ( self._now && self._now.call( performance ) ) || ( new Date().getTime() );
+        return ( this._now && this._now.call( performance ) ) || ( new Date().getTime() );
     },
 
     /**


### PR DESCRIPTION
frameRate setting was not working after update from V3.0-rc0 to v3.0-rc2 .
window.requestAnimationFrame() is always 60 fps. (sorry, i can't find english document)

i checked in Mac OS X 10.9.3 And follow Browsers.
- Chrome 36.0.1985.143
- Firefox 31.0.
