### PR TITLE
Fixed #5865: JS and JSB's LabelTTF _dimensions are not unified

### DIFF
--- a/cocos2d/core/labelttf/CCLabelTTF.js
+++ b/cocos2d/core/labelttf/CCLabelTTF.js
@@ -118,7 +118,7 @@ cc.LabelTTF = cc.Sprite.extend(/** @lends cc.LabelTTF# */{
             strInfo = "";
 
         fontSize = fontSize || 16;
-        dimensions = dimensions || cc.size(0, fontSize);
+        dimensions = dimensions || cc.size(0, 0/*fontSize*/);
         hAlignment = hAlignment || cc.TEXT_ALIGNMENT_LEFT;
         vAlignment = vAlignment || cc.VERTICAL_TEXT_ALIGNMENT_TOP;
 


### PR DESCRIPTION
js: LabelTTF _dimensions.height init is word's height.
jsb: LabelTTF _dimensions.height init is 0.
