### PR TITLE
[Fix] - Polyfill for bind

### DIFF
--- a/CCBoot.js
+++ b/CCBoot.js
@@ -1962,10 +1962,25 @@ cc.game = {
 cc.game._initConfig();
 //+++++++++++++++++++++++++something about CCGame end+++++++++++++++++++++++++++++
 
-Function.prototype.bind = Function.prototype.bind || function (bind) {
-    var self = this;
-    return function () {
-        var args = Array.prototype.slice.call(arguments);
-        return self.apply(bind || null, args);
-    };
+Function.prototype.bind = Function.prototype.bind || function (oThis) {
+    if (typeof this !== "function") {
+        // closest thing possible to the ECMAScript 5
+        // internal IsCallable function
+        throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
+    }
+
+    var aArgs = Array.prototype.slice.call(arguments, 1),
+        fToBind = this,
+        fNOP = function () {},
+        fBound = function () {
+            return fToBind.apply(this instanceof fNOP && oThis
+                ? this
+                : oThis,
+                aArgs.concat(Array.prototype.slice.call(arguments)));
+        };
+
+    fNOP.prototype = this.prototype;
+    fBound.prototype = new fNOP();
+
+    return fBound;
 };


### PR DESCRIPTION
In case of multi params from `bind` function, it leads wrong case because at now we only accept one param in `bind`. I think you should use `bind` function polyfill which was provided by Mozilla [Function bind](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
