### PR TITLE
[Fix] - Facebook pluginx dialog

### DIFF
--- a/external/pluginx/platform/facebook.js
+++ b/external/pluginx/platform/facebook.js
@@ -310,10 +310,6 @@ plugin.extend('facebook', {
             }else{
                 return;
             }
-        }else{
-            if(!info['href']){
-                return;
-            }
         }
 
         if(


### PR DESCRIPTION
There is a case when method is 'apprequests' and we don't need `href` attribute in `info`. If we check `info` doesn't have `href` attribute, Facebook UI for 'apprequests' will be not trigger
You can check here [Facebook Requests](https://developers.facebook.com/docs/games/requests/v2.1)
