### PR TITLE
Issue #5938: Add getTitleRenderer to UIButton

### DIFF
--- a/extensions/ccui/uiwidgets/UIButton.js
+++ b/extensions/ccui/uiwidgets/UIButton.js
@@ -736,6 +736,15 @@ ccui.Button = ccui.Widget.extend(/** @lends ccui.Button# */{
     },
 
     /**
+     * Get the title renderer.
+     * title ttf object.
+     * @returns {cc.LabelTTF}
+     */
+    getTitleRenderer: function(){
+        return this._titleRenderer;
+    },
+
+    /**
      * Sets title text to ccui.Button
      * @param {String} text
      */


### PR DESCRIPTION
Add getTitleRenderer to UIButton
Fixed cocos2d/cocos2d-js#1053
