### PR TITLE
Issue #5939: LabelAtlas._cascadeOpacityEnabled is false

### DIFF
--- a/cocos2d/labels/CCLabelAtlas.js
+++ b/cocos2d/labels/CCLabelAtlas.js
@@ -73,6 +73,9 @@ cc.LabelAtlas = cc.AtlasNode.extend(/** @lends cc.LabelAtlas# */{
     ctor: function (strText, charMapFile, itemWidth, itemHeight, startCharMap) {
         cc.AtlasNode.prototype.ctor.call(this);
 
+        this._cascadeOpacityEnabled = true;
+        this._cascadeColorEnabled = true;
+
         charMapFile && cc.LabelAtlas.prototype.initWithString.call(this, strText, charMapFile, itemWidth, itemHeight, startCharMap);
     },
 


### PR DESCRIPTION
Cannot cascade caused property does not transfer
