### PR TITLE
Fixed TMX drawing bug

### DIFF
--- a/cocos2d/tilemap/CCTMXLayer.js
+++ b/cocos2d/tilemap/CCTMXLayer.js
@@ -263,10 +263,10 @@ cc.TMXLayer = cc.SpriteBatchNode.extend(/** @lends cc.TMXLayer# */{
                     var selSubCanvas = locSubCacheCanvasArr[i];
                     if (this.layerOrientation === cc.TMX_ORIENTATION_HEX)
                         context.drawImage(locSubCacheCanvasArr[i], 0, 0, selSubCanvas.width, selSubCanvas.height,
-                                posX + i * this._subCacheWidth, -(posY + locCanvasHeight) + halfTileSize, selSubCanvas.width * eglViewer._scaleX, locCanvasHeight);
+                                posX + i * this._subCacheWidth * eglViewer._scaleX, -(posY + locCanvasHeight) + halfTileSize, selSubCanvas.width * eglViewer._scaleX, locCanvasHeight);
                     else
                         context.drawImage(locSubCacheCanvasArr[i], 0, 0, selSubCanvas.width, selSubCanvas.height,
-                                posX + i * this._subCacheWidth, -(posY + locCanvasHeight), selSubCanvas.width * eglViewer._scaleX, locCanvasHeight);
+                                posX + i * this._subCacheWidth * eglViewer._scaleX, -(posY + locCanvasHeight), selSubCanvas.width * eglViewer._scaleX, locCanvasHeight);
                 }
             } else{
                 if (this.layerOrientation === cc.TMX_ORIENTATION_HEX)


### PR DESCRIPTION
If the current window size isn't the same as the design resolution size, cached canvases will draw at an offset, making parts of the tileset overlap or have giant gaps in them, but only on the X axis.

`locCanvasHeight` factors in `eglViewer._scaleY`, but the X axis has no such factor, so I just multiplied it in directly. This fixes the bug, at least on my system (Windows 8.1, Internet Explorer 11), but it doesn't look like the fix is tied to any specific platform.
