### PR TITLE
ccui.TextBMFont ’s wrong property setting

### DIFF
--- a/extensions/ccui/uiwidgets/UITextBMFont.js
+++ b/extensions/ccui/uiwidgets/UITextBMFont.js
@@ -191,7 +191,7 @@ var _p = ccui.TextBMFont.prototype;
 // Extended properties
 /** @expose */
 _p.string;
-cc.defineGetterSetter(_p, "string", _p.getString, _p.setStringValue);
+cc.defineGetterSetter(_p, "string", _p.getString, _p.setString);
 
 _p = null;
 


### PR DESCRIPTION
http://discuss.cocos2d-x.org/t/ccui-textbmfont-s-wrong-property-setting/17675

var txt = new TextBMFont(...); txt.string = "blahblah";

this code dosen't work on HTML5.

I tested it, and fixed it.
