### PR TITLE
Add getSprite() method for compatible with cocos2d-x

### DIFF
--- a/extensions/gui/control-extension/CCScale9Sprite.js
+++ b/extensions/gui/control-extension/CCScale9Sprite.js
@@ -278,6 +278,9 @@ cc.Scale9Sprite = cc.Node.extend(/** @lends cc.Scale9Sprite# */{
     getOriginalSize: function () {
         return cc.size(this._originalSize);
     },
+    getSprite: function () {
+        return this._scale9Image;
+    },
 
     //if the preferredSize component is given as -1, it is ignored
     getPreferredSize: function () {


### PR DESCRIPTION
Cocos2d-x's CCScale9Sprite is have getSprite() method for getting
scale9Image field but cocos2d-html5 is not. Need to be fixed for
compatibility.
