### PR TITLE
Fixed #2436: correct a mistake of cc.ClippingNode

### DIFF
--- a/cocos2d/clipping-nodes/CCClippingNode.js
+++ b/cocos2d/clipping-nodes/CCClippingNode.js
@@ -128,6 +128,7 @@ cc.ClippingNode = cc.Node.extend(/** @lends cc.ClippingNode# */{
         this._stencil = stencil;
         this.alphaThreshold = 1;
         this.inverted = false;
+        return true;
     },
 
     /**


### PR DESCRIPTION
Correct a mistake of cc.ClippingNode
