### PR TITLE
Fixed console.log.apply is not function (ie9)

### DIFF
--- a/CCDebugger.js
+++ b/CCDebugger.js
@@ -310,13 +310,8 @@ cc._initDebugSetting = function (mode) {
                 locLog(cc.formatStr.apply(cc, arguments));
             };
         }
-    } else if(console && console.log.apply){
+    } else if(console && console.log.apply){//console is null when user doesn't open dev tool on IE9
         //log to console
-        if(!console){//console is null when user doesn't open dev tool on IE9
-            return;
-        }else if(!console.log.apply){
-            return;
-        }
 
         cc.error = function(){
             return console.error.apply(console, arguments);


### PR DESCRIPTION
Fixed console.log.apply is not function (ie9)
