### PR TITLE
处理多处使用同一资源 导致重复addSpriteFrames

### DIFF
--- a/extensions/cocostudio/reader/timeline/CSLoader.js
+++ b/extensions/cocostudio/reader/timeline/CSLoader.js
@@ -268,6 +268,7 @@ ccs.csLoader = {
         // decode plist
         var textureSize = buffer["textures"].length;
         //cc.log("textureSize = %d", textureSize);
+        var frameCaches = {};
         for (var i = 0; i < textureSize; ++i)
         {
             var plist = buffer["textures"][i];
@@ -276,7 +277,10 @@ ccs.csLoader = {
             //cc.log("png = %s", png);
             plist = this._protocolBuffersPath + plist;
             png = this._protocolBuffersPath + png;
-            cc.spriteFrameCache.addSpriteFrames(plist, png);
+            frameCaches[plist] = png;
+        }
+        for(var plist in frameCaches){
+            cc.spriteFrameCache.addSpriteFrames(plist,frameCaches[plist]);
         }
         var fileDesignWidth = buffer["designWidth"];
         var fileDesignHeight = buffer["designHeight"];


### PR DESCRIPTION
如果在一个csb文件里 使用一个plist文件多次 会导致 buffer["textures"].length过大 
导致重复cc.spriteFrameCache.addSpriteFrames();
