### PR TITLE
Fixed a bug that sprite update color terminated unexpectedly

### DIFF
--- a/cocos2d/core/sprites/CCSprite.js
+++ b/cocos2d/core/sprites/CCSprite.js
@@ -1492,10 +1492,6 @@ if (cc._renderType === cc._RENDER_TYPE_CANVAS) {
     _p.updateDisplayedColor = function (parentColor) {
         var _t = this;
         cc.Node.prototype.updateDisplayedColor.call(_t, parentColor);
-        var oColor = _t._oldDisplayColor;
-        var nColor = _t._displayedColor;
-        if (oColor.r === nColor.r && oColor.g === nColor.g && oColor.b === nColor.b)
-            return;
 
         _t._changeTextureColor();
         _t._setNodeDirtyForCache();


### PR DESCRIPTION
Here is only judged the oldDisplayColor, without checking parentColor.

But adds a if, seems too much. So delete it here...
