### PR TITLE
Fixed ios 8 webAudio play is not sound...(change to normal audio)

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -24,7 +24,7 @@
  THE SOFTWARE.
  ****************************************************************************/
 
-if (cc.sys._supportWebAudio && !/OS 8_1 /.test(navigator.appVersion)) {
+if (cc.sys._supportWebAudio && (!/OS 8_1 /.test(navigator.appVersion) && cc.sys.browserType === cc.sys.BROWSER_TYPE_SAFARI)) {
     var _ctx = cc.webAudioContext = new (window.AudioContext || window.webkitAudioContext || window.mozAudioContext)();
     /**
      * A class of Web Audio.


### PR DESCRIPTION
Fixed ios 8 webAudio play is not sound...(change to normal audio)
