### PR TITLE
Fixed #2416: SpriteBatchNode needn't check texture when adding a child to it.

### DIFF
--- a/cocos2d/core/sprites/CCSpriteBatchNode.js
+++ b/cocos2d/core/sprites/CCSpriteBatchNode.js
@@ -561,14 +561,8 @@ cc.SpriteBatchNode = cc.Node.extend(/** @lends cc.SpriteBatchNode# */{
     addChild: function (child, zOrder, tag) {
         cc.assert(child != null, cc._LogInfos.CCSpriteBatchNode_addChild_3);
 
-        if (!(child instanceof cc.Sprite)) {
-            cc.log(cc._LogInfos.Sprite_addChild_4);
+        if(!this._renderCmd.isValidChild(child))
             return;
-        }
-        if (child.texture != this._renderCmd.getTexture()) {
-            cc.log(cc._LogInfos.Sprite_addChild_5);
-            return;
-        }
 
         zOrder = (zOrder == null) ? child.zIndex : zOrder;
         tag = (tag == null) ? child.tag : tag;

--- a/cocos2d/core/sprites/CCSpriteBatchNodeCanvasRenderCmd.js
+++ b/cocos2d/core/sprites/CCSpriteBatchNodeCanvasRenderCmd.js
@@ -36,6 +36,14 @@
 
     proto.checkAtlasCapacity = function(){};
 
+    proto.isValidChild = function(child){
+        if (!(child instanceof cc.Sprite)) {
+            cc.log(cc._LogInfos.Sprite_addChild_4);
+            return false;
+        }
+        return true;
+    };
+
     proto.initWithTexture = function(texture, capacity){
         this._originalTexture = texture;
         this._texture = texture;

--- a/cocos2d/core/sprites/CCSpriteBatchNodeWebGLRenderCmd.js
+++ b/cocos2d/core/sprites/CCSpriteBatchNodeWebGLRenderCmd.js
@@ -34,6 +34,18 @@
     var proto = cc.SpriteBatchNode.WebGLRenderCmd.prototype = Object.create(cc.Node.WebGLRenderCmd.prototype);
     proto.constructor = cc.SpriteBatchNode.WebGLRenderCmd;
 
+    proto.isValidChild = function(child){
+        if (!(child instanceof cc.Sprite)) {
+            cc.log(cc._LogInfos.Sprite_addChild_4);
+            return false;
+        }
+        if (child.texture != this.getTexture()) {
+            cc.log(cc._LogInfos.Sprite_addChild_5);
+            return false;
+        }
+        return true;
+    };
+
     proto.rendering = function () {
         var node = this._node;
         if (this._textureAtlas.totalQuads === 0)


### PR DESCRIPTION
SpriteBatchNode needn't check texture when adding a child to it.
