### PR TITLE
fixed #1284: It's need to add scale parm when calc word wrap

### DIFF
--- a/cocos2d/labels/CCLabelBMFont.js
+++ b/cocos2d/labels/CCLabelBMFont.js
@@ -548,7 +548,7 @@ cc.LabelBMFont = cc.SpriteBatchNode.extend(/** @lends cc.LabelBMFont# */{
             var oldArrLength = 0;
             for (i = 0; i < stringArr.length; i++) {
                 oldArrLength = stringArr.length;
-                this._checkWarp(stringArr, i, self._width, newWrapNum);
+                this._checkWarp(stringArr, i, self._width * this._scaleX, newWrapNum);
                 if (oldArrLength < stringArr.length)
                 {
                     newWrapNum++;


### PR DESCRIPTION
fixed the bug:The font show error after CCLabelBMFont setScale.

i test it in chrome.
mode:canvas,webgl