### PR TITLE
Fixed Cocos2d-js/#1292: Gets the wrong OS type to sys.os when OS is Linux

### DIFF
--- a/CCBoot.js
+++ b/CCBoot.js
@@ -1561,7 +1561,7 @@ cc._initSys = function (config, CONFIG_KEY) {
     if (nav.appVersion.indexOf("Win") != -1) osName = sys.OS_WINDOWS;
     else if (iOS) osName = sys.OS_IOS;
     else if (nav.appVersion.indexOf("Mac") != -1) osName = sys.OS_OSX;
-    else if (nav.appVersion.indexOf("X11") != -1) osName = sys.OS_UNIX;
+    else if (nav.appVersion.indexOf("X11") != -1 && nav.appVersion.indexOf("Linux") == -1) osName = sys.OS_UNIX;
     else if (isAndroid) osName = sys.OS_ANDROID;
     else if (nav.appVersion.indexOf("Linux") != -1) osName = sys.OS_LINUX;
 


### PR DESCRIPTION
Fixed a bug in CCBoot.js that Gets the wrong OS type to sys.os when OS is Linux