### PR TITLE
Fixed cocos2d/cocos2d-js/#1309: ccui.Widget can't touch when it reused.

### DIFF
--- a/extensions/ccui/base-classes/UIWidget.js
+++ b/extensions/ccui/base-classes/UIWidget.js
@@ -145,6 +145,9 @@ ccui.Widget = ccui.ProtectedNode.extend(/** @lends ccui.Widget# */{
      * @override
      */
     onEnter: function () {
+        var locListener = this._touchListener;
+        if (locListener && !locListener._isRegistered() && this._touchEnabled)
+            cc.eventManager.addListener(locListener, this);
         if(!this._usingLayoutComponent)
             this.updateSizeAndPosition();
         cc.ProtectedNode.prototype.onEnter.call(this);


### PR DESCRIPTION
ccui.Widget can't touch when it reused.