### PR TITLE
register loader for JavaScript (.js) files

### DIFF
--- a/cocos2d/core/platform/CCLoaders.js
+++ b/cocos2d/core/platform/CCLoaders.js
@@ -37,6 +37,13 @@ cc._jsonLoader = {
 };
 cc.loader.register(["json", "ExportJson"], cc._jsonLoader);
 
+cc._jsLoader = {
+    load : function(realUrl, url, res, cb){
+        cc.loader.loadJs(realUrl, cb);
+    }
+};
+cc.loader.register(["js"], cc._jsLoader);
+
 cc._imgLoader = {
     load : function(realUrl, url, res, cb){
         cc.loader.cache[url] =  cc.loader.loadImg(realUrl, function(err, img){


### PR DESCRIPTION
This small addition will make the loader automatically handle .js files. This allows for lazy-loading of Scene-specific code rather than having to pre-specify everything in the project.json jsList.