### PR TITLE
fixed typos in cc.ClippingNode.WebGLRenderCmd and cc.ParticleSystem.WebGLRenderCmd creation

### DIFF
--- a/cocos2d/clipping-nodes/CCClippingNodeWebGLRenderCmd.js
+++ b/cocos2d/clipping-nodes/CCClippingNodeWebGLRenderCmd.js
@@ -44,7 +44,7 @@
         this._mask_layer_le = null;
     };
 
-    var proto = cc.ClippingNode.WebGLRenderCmd.prototype = Object.create(cc.Node.CanvasRenderCmd.prototype);
+    var proto = cc.ClippingNode.WebGLRenderCmd.prototype = Object.create(cc.Node.WebGLRenderCmd.prototype);
     proto.constructor = cc.ClippingNode.WebGLRenderCmd;
 
     cc.ClippingNode.WebGLRenderCmd._init_once = null;

--- a/cocos2d/particle/CCParticleSystemWebGLRenderCmd.js
+++ b/cocos2d/particle/CCParticleSystemWebGLRenderCmd.js
@@ -36,7 +36,7 @@
         this._quadsArrayBuffer = null;
     };
     var proto = cc.ParticleSystem.WebGLRenderCmd.prototype = Object.create(cc.Node.WebGLRenderCmd.prototype);
-    proto.constructor = cc.ParticleSystem.CanvasRenderCmd;
+    proto.constructor = cc.ParticleSystem.WebGLRenderCmd;
 
     proto.getDrawMode = function(){};
     proto.setDrawMode = function(drawMode){};


### PR DESCRIPTION
fixed typos in cc.ClippingNode.WebGLRenderCmd and cc.ParticleSystem.WebGLRenderCmd creation which resulted in wrong clipping node rendering