### PR TITLE
Fixed issue with incorrect work of cc.Screen.fullscreen()

### DIFF
--- a/cocos2d/core/platform/CCScreen.js
+++ b/cocos2d/core/platform/CCScreen.js
@@ -92,7 +92,7 @@ cc.screen = /** @lends cc.screen# */{
 		    }
 	    }
 
-		this._supportsFullScreen = (this._fn.requestFullscreen != undefined);
+	this._supportsFullScreen = (this._fn.requestFullscreen != undefined);
         this._touchEvent = ('ontouchstart' in window) ? 'touchstart' : 'mousedown';
     },
 
@@ -101,7 +101,7 @@ cc.screen = /** @lends cc.screen# */{
      * @returns {Boolean}
      */
     fullScreen: function() {
-	    return this._supportsFullScreen && document[ this._fn.fullscreenEnabled ];
+	    return this._supportsFullScreen && document[this._fn.fullscreenElement];
     },
 
     /**

--- a/cocos2d/core/platform/CCScreen.js
+++ b/cocos2d/core/platform/CCScreen.js
@@ -2,19 +2,19 @@
  Copyright (c) 2008-2010 Ricardo Quesada
  Copyright (c) 2011-2012 cocos2d-x.org
  Copyright (c) 2013-2014 Chukong Technologies Inc.
-
+ 
  http://www.cocos2d-x.org
-
+ 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
-
+ 
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
-
+ 
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,116 +32,119 @@
  */
 cc.screen = /** @lends cc.screen# */{
     _supportsFullScreen: false,
-	// the pre fullscreenchange function
+    // the pre fullscreenchange function
     _preOnFullScreenChange: null,
     _touchEvent: "",
-	_fn: null,
-	// Function mapping for cross browser support
-	_fnMap: [
-		[
-			'requestFullscreen',
-			'exitFullscreen',
-			'fullscreenchange',
-			'fullscreenEnabled',
-			'fullscreenElement'
-		],
-		[
-			'requestFullScreen',
-			'exitFullScreen',
-			'fullScreenchange',
-			'fullScreenEnabled',
-			'fullScreenElement'
-		],
-		[
-			'webkitRequestFullScreen',
-			'webkitCancelFullScreen',
-			'webkitfullscreenchange',
-			'webkitIsFullScreen',
-			'webkitCurrentFullScreenElement'
-		],
-		[
-			'mozRequestFullScreen',
-			'mozCancelFullScreen',
-			'mozfullscreenchange',
-			'mozFullScreen',
-			'mozFullScreenElement'
-		],
-		[
-			'msRequestFullscreen',
-			'msExitFullscreen',
-			'MSFullscreenChange',
-			'msFullscreenEnabled',
-			'msFullscreenElement'
-		]
-	],
-
+    _fn: null,
+    // Function mapping for cross browser support
+    _fnMap: [
+        [
+            'requestFullscreen',
+            'exitFullscreen',
+            'fullscreenchange',
+            'fullscreenEnabled',
+            'fullscreenElement'
+        ],
+        [
+            'requestFullScreen',
+            'exitFullScreen',
+            'fullScreenchange',
+            'fullScreenEnabled',
+            'fullScreenElement'
+        ],
+        [
+            'webkitRequestFullScreen',
+            'webkitCancelFullScreen',
+            'webkitfullscreenchange',
+            'webkitIsFullScreen',
+            'webkitCurrentFullScreenElement'
+        ],
+        [
+            'mozRequestFullScreen',
+            'mozCancelFullScreen',
+            'mozfullscreenchange',
+            'mozFullScreen',
+            'mozFullScreenElement'
+        ],
+        [
+            'msRequestFullscreen',
+            'msExitFullscreen',
+            'MSFullscreenChange',
+            'msFullscreenEnabled',
+            'msFullscreenElement'
+        ]
+    ],
+    
     /**
      * initialize
      * @function
      */
     init: function () {
-	    this._fn = {};
-	    var i, val, map = this._fnMap, valL;
-	    for (i = 0, l = map.length; i < l; i++ ) {
-		    val = map[ i ];
-		    if ( val && val[1] in document ) {
-			    for ( i = 0, valL = val.length; i < valL; i++ ) {
-				    this._fn[ map[0][ i ] ] = val[ i ];
-			    }
-			    break;
-		    }
-	    }
+        this._fn = {};
+        var i, val, map = this._fnMap, valL;
+        for (i = 0, l = map.length; i < l; i++) {
+            val = map[i];
+            if (val && val[1] in document) {
+                for (i = 0, valL = val.length; i < valL; i++) {
+                    this._fn[map[0][i]] = val[i];
+                }
+                break;
+            }
+        }
 
-	this._supportsFullScreen = (this._fn.requestFullscreen != undefined);
+        this._supportsFullScreen = (typeof this._fn.requestFullscreen !== 'undefined');
         this._touchEvent = ('ontouchstart' in window) ? 'touchstart' : 'mousedown';
     },
-
+    
     /**
      * return true if it's full now.
      * @returns {Boolean}
      */
-    fullScreen: function() {
-	    return this._supportsFullScreen && document[this._fn.fullscreenElement];
+    fullScreen: function () {
+        return this._supportsFullScreen && document[this._fn.fullscreenElement];
     },
-
+    
     /**
      * change the screen to full mode.
      * @param {Element} element
      * @param {Function} onFullScreenChange
      */
     requestFullScreen: function (element, onFullScreenChange) {
-	    if (!this._supportsFullScreen) return;
+        if (!this._supportsFullScreen) {
+            return;
+        }
 
-	    element = element || document.documentElement;
-	    element[ this._fn.requestFullscreen ]();
+        element = element || document.documentElement;
+        element[this._fn.requestFullscreen]();
 
-	    if (onFullScreenChange) {
-		    var eventName = this._fn.fullscreenchange;
-		    if (this._preOnFullScreenChange)
-			    document.removeEventListener(eventName, this._preOnFullScreenChange);
-		    this._preOnFullScreenChange = onFullScreenChange;
+        if (onFullScreenChange) {
+            var eventName = this._fn.fullscreenchange;
+            if (this._preOnFullScreenChange) {
+                document.removeEventListener(eventName, this._preOnFullScreenChange);
+            }
+            this._preOnFullScreenChange = onFullScreenChange;
             cc._addEventListener(document, eventName, onFullScreenChange, false);
-	    }
+        }
 
-        return element[ this._fn.requestFullscreen ]();
+        return element[this._fn.requestFullscreen]();
     },
-
+    
     /**
      * exit the full mode.
      * @return {Boolean}
      */
     exitFullScreen: function () {
-        return this._supportsFullScreen ? document[ this._fn.exitFullscreen ]() : true;
+        return this._supportsFullScreen ? document[this._fn.exitFullscreen]() : true;
     },
-
+    
     /**
      * Automatically request full screen with a touch/click event
      * @param {Element} element
      * @param {Function} onFullScreenChange
      */
     autoFullScreen: function (element, onFullScreenChange) {
-	    element = element || document.body;
-	    var touchTarget = cc._canvas || element;
+        element = element || document.body;
+        var touchTarget = cc._canvas || element;
         var theScreen = this;
         // Function bind will be too complicated here because we need the callback function's reference to remove the listener
         function callback() {


### PR DESCRIPTION
Using <b>fullscreenElement</b> for determining on/off fullscreen mode instead of <b>fullscreenEnabled</b>.

According to https://developer.mozilla.org/en/docs/DOM/Using_fullscreen_mode:
<b>fullscreenEnabled</b> tells whether or not the document is currently in a state that would allow fullscreen mode to be requested.
<b>fullscreenElement</b> tells the element that's currently being displayed fullscreen. If this is non-null, the document is in fullscreen mode. If this is null, the document is not in fullscreen mode.
