### PR TITLE
audioEngine not playing in Firefox, using minified/compiled lib

### DIFF
--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -134,11 +134,16 @@
         else
             cc.__audioSupport = supportTable[sys.BROWSER_TYPE_SAFARI];
     }else{
-        //Desktop support all
-        if(cc.sys.browserType != cc.sys.BROWSER_TYPE_IE)
-            cc.__audioSupport = supportTable["common"];
-        else
-            cc.__audioSupport = supportTable[sys.BROWSER_TYPE_IE];
+      switch(sys.browserType){
+          case sys.BROWSER_TYPE_IE:
+              cc.__audioSupport = supportTable[sys.BROWSER_TYPE_IE];
+              break;
+          case sys.BROWSER_TYPE_FIREFOX:
+              cc.__audioSupport = supportTable[sys.BROWSER_TYPE_FIREFOX];
+              break;
+          default:
+              cc.__audioSupport = supportTable["common"];
+      }
     }
 
     if(DEBUG){


### PR DESCRIPTION
Load the right supportTable to support BROWSER_TYPE_FIREFOX settings