### PR TITLE
Fixed bug that is Scale9sprite cap error when no pre loading picture

### DIFF
--- a/extensions/ccui/base-classes/UIScale9Sprite.js
+++ b/extensions/ccui/base-classes/UIScale9Sprite.js
@@ -466,6 +466,10 @@ ccui.Scale9Sprite = cc.Node.extend(/** @lends ccui.Scale9Sprite# */{
         this._textureLoaded = locLoaded;
         if(!locLoaded){
             texture.addEventListener("load", function(sender){
+                if(this._capInsets.width === 0 && this._capInsets.height === 0){
+                    this._capInsets.width = sender._contentSize.width;
+                    this._capInsets.height = sender._contentSize.height;
+                }
                 // the texture is rotated on Canvas render mode, so isRotated always is false.
                 var preferredSize = this._preferredSize;
                 preferredSize = cc.size(preferredSize.width, preferredSize.height);
@@ -475,6 +479,11 @@ ccui.Scale9Sprite = cc.Node.extend(/** @lends ccui.Scale9Sprite# */{
                 this._positionsAreDirty = true;
                 this.dispatchEvent("load");
             }, this);
+        }else{
+            if(this._capInsets.width === 0 && this._capInsets.height === 0){
+                capInsets.width = texture._contentSize.width;
+                capInsets.height = texture._contentSize.height;
+            }
         }
 
         return this.initWithBatchNode(new cc.SpriteBatchNode(file, 9), rect, false, capInsets);

--- a/extensions/gui/control-extension/CCScale9Sprite.js
+++ b/extensions/gui/control-extension/CCScale9Sprite.js
@@ -461,6 +461,10 @@ cc.Scale9Sprite = cc.Node.extend(/** @lends cc.Scale9Sprite# */{
         this._textureLoaded = locLoaded;
         if(!locLoaded){
             texture.addEventListener("load", function(sender){
+                if(this._capInsets.width === 0 && this._capInsets.height === 0){
+                    this._capInsets.width = sender._contentSize.width;
+                    this._capInsets.height = sender._contentSize.height;
+                }
                 // the texture is rotated on Canvas render mode, so isRotated always is false.
                 var preferredSize = this._preferredSize;
                 preferredSize = cc.size(preferredSize.width, preferredSize.height);
@@ -470,6 +474,11 @@ cc.Scale9Sprite = cc.Node.extend(/** @lends cc.Scale9Sprite# */{
                 this._positionsAreDirty = true;
                 this.dispatchEvent("load");
             }, this);
+        }else{
+            if(this._capInsets.width === 0 && this._capInsets.height === 0){
+                capInsets.width = texture._contentSize.width;
+                capInsets.height = texture._contentSize.height;
+            }
         }
 
         return this.initWithBatchNode(new cc.SpriteBatchNode(file, 9), rect, false, capInsets);


### PR DESCRIPTION
Scale9sprite capInsets is error when texture dosn't pre load the picture .
