### PR TITLE
Fixed #2776: Fixed a bug of cc.ClippingNode that it doesn't work when set Inverted to true on Canvas Mode.

### DIFF
--- a/cocos2d/clipping-nodes/CCClippingNodeCanvasRenderCmd.js
+++ b/cocos2d/clipping-nodes/CCClippingNodeCanvasRenderCmd.js
@@ -104,8 +104,8 @@
          if(!stencil)
             return;
         var node = this._node;
-        if(stencil._renderCmd && stencil._renderCmd._setBlendFuncStr)
-            stencil._renderCmd._setBlendFuncStr(node.inverted ? "destination-out" : "destination-in");
+        if(stencil._renderCmd && stencil._renderCmd._blendFuncStr)
+            stencil._renderCmd._blendFuncStr = (node.inverted ? "destination-out" : "destination-in");
 
         if(!stencil._children)
             return;


### PR DESCRIPTION
Fixed a bug of cc.ClippingNode that it doesn't work when set Inverted to true on Canvas Mode.