### PR TITLE
Fix NotificationNode event listeners priority

### DIFF
--- a/cocos2d/core/event-manager/CCEventManager.js
+++ b/cocos2d/core/event-manager/CCEventManager.js
@@ -307,7 +307,27 @@ cc.eventManager = /** @lends cc.eventManager# */{
         var notificationNode = cc.director.getNotificationNode();
         if(notificationNode) {
             this._visitTarget(notificationNode, true);
-            this._visitTarget(rootNode, false);
+
+            // save result in temp variable for later use
+            var notificationNodePriorityMap = this._nodePriorityMap,
+                notificationNodePriorityIndex = this._nodePriorityIndex;
+
+            // reset
+            this._nodePriorityIndex = 0;
+            this._nodePriorityMap = {};
+
+            // visit rootNode
+            this._visitTarget(rootNode, true);
+
+            // update priority map
+            for(var id in notificationNodePriorityMap) {
+                if(notificationNodePriorityMap.hasOwnProperty(id)) {
+                    this._nodePriorityMap[id] = notificationNodePriorityMap[id] + this._nodePriorityIndex;
+                }
+            }
+            // update index
+            this._nodePriorityIndex += notificationNodePriorityIndex
+
         } else {
             this._visitTarget(rootNode, true);
         }

--- a/cocos2d/core/event-manager/CCEventManager.js
+++ b/cocos2d/core/event-manager/CCEventManager.js
@@ -304,7 +304,13 @@ cc.eventManager = /** @lends cc.eventManager# */{
         this._nodePriorityIndex = 0;
         this._nodePriorityMap = {};
 
-        this._visitTarget(rootNode, true);
+        var notificationNode = cc.director.getNotificationNode();
+        if(notificationNode) {
+            this._visitTarget(notificationNode, true);
+            this._visitTarget(rootNode, false);
+        } else {
+            this._visitTarget(rootNode, true);
+        }
 
         // After sort: priority < 0, > 0
         listeners.getSceneGraphPriorityListeners().sort(this._sortEventListenersOfSceneGraphPriorityDes);


### PR DESCRIPTION
**Problem:**
When notification node is used event listeners are not getting sorted for it and its child nodes.

**Solution:**
If notification node is available consider it as a root and calculate scene graph priority for it first.
If notification node is not available consider scene as a root.

**cocos2d-x related pull request:**
https://github.com/cocos2d/cocos2d-x/pull/11275
