### PR TITLE
Fixed #2811: fixed a bug of cc.eventManager that its sorted order is incorrect

### DIFF
--- a/cocos2d/core/event-manager/CCEventManager.js
+++ b/cocos2d/core/event-manager/CCEventManager.js
@@ -311,8 +311,9 @@ cc.eventManager = /** @lends cc.eventManager# */{
     },
 
     _sortEventListenersOfSceneGraphPriorityDes : function(l1, l2){
-        var locNodePriorityMap = cc.eventManager._nodePriorityMap;
-        if(!l1 || !l2 || !l1._getSceneGraphPriority() || !l2._getSceneGraphPriority())
+        var locNodePriorityMap = cc.eventManager._nodePriorityMap, node1 = l1._getSceneGraphPriority(),
+            node2 = l2._getSceneGraphPriority();
+        if(!l1 || !l2 || !node1 || !node2 || !locNodePriorityMap[node1.__instanceId] || !locNodePriorityMap[node2.__instanceId])
             return -1;
         return locNodePriorityMap[l2._getSceneGraphPriority().__instanceId] - locNodePriorityMap[l1._getSceneGraphPriority().__instanceId];
     },


### PR DESCRIPTION
Fixed #2811: fixed a bug of cc.eventManager that its sorted order is incorrect when some nodes haven't add to scene graph or remove from parent without cleanup.