### PR TITLE
Improved time precision inside cc.Timer.update

### DIFF
--- a/cocos2d/core/CCScheduler.js
+++ b/cocos2d/core/CCScheduler.js
@@ -165,7 +165,7 @@ cc.Timer = cc.Class.extend(/** @lends cc.Timer# */{
             if (this._runForever && !this._useDelay) {//standard timer usage
                 if (this._elapsed >= this._interval) {
                     this.trigger();
-                    this._elapsed = 0;
+                    this._elapsed = (this._interval <= 0) ? 0 : this._elapsed - this._interval;
                 }
             } else {//advanced usage
                 if (this._useDelay) {
@@ -180,7 +180,7 @@ cc.Timer = cc.Class.extend(/** @lends cc.Timer# */{
                     if (this._elapsed >= this._interval) {
                         this.trigger();
 
-                        this._elapsed = 0;
+                        this._elapsed = (this._interval <= 0) ? 0 : this._elapsed - this._interval;
                         this._timesExecuted += 1;
                     }
                 }


### PR DESCRIPTION
Well, I did not find any reason to set Timer._elapsed to 0 instead of subtracting Timer._interval for more precision. Unless, as the change shows, the _interval is some unappropiate number like 0 or less.