### PR TITLE
To fix a bug on the slider within the scaleX may be not 1

### DIFF
--- a/extensions/ccui/uiwidgets/UISlider.js
+++ b/extensions/ccui/uiwidgets/UISlider.js
@@ -458,7 +458,7 @@ ccui.Slider = ccui.Widget.extend(/** @lends ccui.Slider# */{
             var spriteRenderer = this._progressBarRenderer;
             var rect = spriteRenderer.getTextureRect();
             spriteRenderer.setTextureRect(
-                cc.rect(rect.x, rect.y, dis, rect.height),
+                cc.rect(rect.x, rect.y, dis / spriteRenderer._scaleX, rect.height),
                 spriteRenderer.isTextureRectRotated()
             );
         }


### PR DESCRIPTION
http://punchbox.info:3000/issues/18032

When this._progressBarRenderer‘s scaleX not 1, will cause the progress percentage misjudgment