### PR TITLE
objectNamed missing a return

### DIFF
--- a/cocos2d/tilemap/CCTMXObjectGroup.js
+++ b/cocos2d/tilemap/CCTMXObjectGroup.js
@@ -117,7 +117,7 @@ cc.TMXObjectGroup = cc.Class.extend(/** @lends cc.TMXObjectGroup# */{
      * @return {object|Null}
      */
     objectNamed:function (objectName) {
-        this.getObject(objectName);
+        return this.getObject(objectName);
     },
 
     /**


### PR DESCRIPTION
objectNamed missing a return statement (hence always returning null)