### PR TITLE
LayerColor's color will disappear when update transform after open bake

### DIFF
--- a/cocos2d/core/layers/CCLayerCanvasRenderCmd.js
+++ b/cocos2d/core/layers/CCLayerCanvasRenderCmd.js
@@ -223,6 +223,7 @@
             var bakeContext = locBakeSprite.getCacheContext();
             var ctx = bakeContext.getContext();
             locBakeSprite.resetCanvasSize(boundingBox.width, boundingBox.height);
+            ctx.fillStyle = bakeContext._currentFillStyle;
 
             bakeContext.setOffset(0 - boundingBox.x, ctx.canvas.height - boundingBox.height + boundingBox.y );
             locBakeSprite.setPosition(boundingBox.x, boundingBox.y);


### PR DESCRIPTION
The color of the LayerColor may be lost.
When the cache of the state of the canvas is updated from time to time,
FillStyle will be restored.

So They are need to do assignment again.