### PR TITLE
Found a bug in cc.math.Matrix4().inverse() and fixed it

### DIFF
--- a/cocos2d/kazmath/mat4.js
+++ b/cocos2d/kazmath/mat4.js
@@ -181,7 +181,8 @@
      */
     cc.kmMat4Inverse = function (pOut, pM) {
         var inv = new cc.math.Matrix4(pM);
-        if (cc.math.Matrix4._gaussj(inv, identityMatrix) === false)
+        var tmp = new cc.math.Matrix4(identityMatrix);
+        if (cc.math.Matrix4._gaussj(inv, tmp) === false)
             return null;
         pOut.assignFrom(inv);
         return pOut;
@@ -193,7 +194,8 @@
      */
     proto.inverse = function(){    //cc.kmMat4Inverse
         var inv = new cc.math.Matrix4(this);
-        if (cc.math.Matrix4._gaussj(inv, identityMatrix) === false)
+        var tmp = new cc.math.Matrix4(identityMatrix);
+        if (cc.math.Matrix4._gaussj(inv, tmp) === false)
             return null;
         return inv;
     };


### PR DESCRIPTION
The `cc.math.Matrix4._gaussj` function changes the global var `identityMatrix` and makes the following calculations wrong.

See the v2.x of mat4.js, https://github.com/cocos2d/cocos2d-html5/blob/v2.x/cocos2d/kazmath/mat4.js#L166