### PR TITLE
Animations with only one frame are allowed now.

### DIFF
--- a/extensions/cocostudio/action/CCActionNode.js
+++ b/extensions/cocostudio/action/CCActionNode.js
@@ -266,13 +266,17 @@ ccs.ActionNode = ccs.Class.extend(/** @lends ccs.ActionNode# */{
             var locSequenceArray = [];
             for (var j = 0; j < locArray.length; j++) {
                 var locFrame = locArray[j];
+                var locAction = null;
                 if (j !== 0) {
                     var locSrcFrame = locArray[j - 1];
                     var locDuration = (locFrame.frameIndex - locSrcFrame.frameIndex) * this.getUnitTime();
-                    var locAction = locFrame.getAction(locDuration);
-                    if(locAction)
-                        locSequenceArray.push(locAction);
+                    locAction = locFrame.getAction(locDuration);
                 }
+                else {
+                    locAction = locFrame.getAction(0);
+                }
+                if(locAction)
+                    locSequenceArray.push(locAction);
             }
             if(locSequenceArray){
                 var locSequence = cc.sequence(locSequenceArray);


### PR DESCRIPTION
If an animation with only a frame is created on Cocos Studio UI 1.6, it is loaded in native (win32, android, iOS...) correctly, but not in web (HTML5). Example:

![image](https://cloud.githubusercontent.com/assets/3737721/7534707/535903b0-f57d-11e4-93dc-7dffbf0a7379.png)

The behaviour is the same now.