### PR TITLE
Polygon Points property change for consistency between frameworks

### DIFF
--- a/cocos2d/tilemap/CCTMXXMLParser.js
+++ b/cocos2d/tilemap/CCTMXXMLParser.js
@@ -783,7 +783,7 @@ cc.TMXMapInfo = cc.SAXParser.extend(/** @lends cc.TMXMapInfo# */{
                         if(polygonProps && polygonProps.length > 0) {
                             var selPgPointStr = polygonProps[0].getAttribute('points');
                             if(selPgPointStr)
-                                objectProp["polygonPoints"] = this._parsePointsString(selPgPointStr);
+                                objectProp["points"] = this._parsePointsString(selPgPointStr);
                         }
 
                         //polyline


### PR DESCRIPTION
Fixes consistency issue by changing “polygonPoints” property to
“points” for storage of polygon points in CCTMXXMLParser.js. This
allows CCTMXXMLParser.js to behave the same as CCTMXXMLParser.cpp in
the other framework.