### PR TITLE
Fix typo in AUTHORS.txt

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,6 +1,6 @@
 Cocos2d-html5 authors
 
-(ordered by the join in time)
+(Ordered by join time)
 
 Core Developers:
 


### PR DESCRIPTION
Altered sentence explaining how authors were ordered so as to fix its grammar and more clearly convey its meaning.