### PR TITLE
fixed CCProgressTimerCanvasRenderCmd to properly show colorized sprites;

### DIFF
--- a/cocos2d/progress-timer/CCProgressTimerCanvasRenderCmd.js
+++ b/cocos2d/progress-timer/CCProgressTimerCanvasRenderCmd.js
@@ -90,7 +90,7 @@
 
         //draw sprite
         var image = locSprite._texture.getHtmlElementObj();
-        if (locSprite._colorized) {
+        if (locSprite._renderCmd._colorized) {
             context.drawImage(image,
                 0, 0, locTextureCoord.width, locTextureCoord.height,
                 locX * scaleX, locY * scaleY, locWidth * scaleX, locHeight * scaleY);
@@ -226,10 +226,10 @@
             spriteCmd._syncDisplayOpacity();
         }
 
-/*        if(colorDirty || opacityDirty){
+        if(colorDirty || opacityDirty){
             spriteCmd._updateColor();
-            this._updateColor();
-        }*/
+            //this._updateColor();
+        }
 
         if (locFlag & flags.transformDirty) {
             //update the transform
@@ -256,10 +256,10 @@
             spriteCmd._updateDisplayOpacity();
         }
 
-/*        if(colorDirty || opacityDirty){
+        if(colorDirty || opacityDirty){
             spriteCmd._updateColor();
-            this._updateColor();
-        }*/
+            //this._updateColor();
+        }
 
         if(locFlag & flags.transformDirty){
             //update the transform


### PR DESCRIPTION
CCProgressTimer.setSprite didn't worked on canvas renderer.

Reproduce steps:
add this code to Template project at the end of myApp.js ctor function:

        var timer = new cc.ProgressTimer(new cc.Sprite(s_HelloWorld));
        timer.setType(cc.ProgressTimer.TYPE_RADIAL);
        timer.setReverseDirection(true);
        timer.setMidpoint(cc.p(0.5, 0.5));
        timer.setBarChangeRate(cc.p(1, 0));
        timer.setPercentage(75);
        timer.setColor(cc.color(128, 128, 128));
        timer.setPosition(size.width / 2, size.height / 2);
        this.addChild(timer);

and set render mode to 1 (canvas) in project.js;
result before fix:
![screen shot 2015-05-26 at 13 32 10](https://cloud.githubusercontent.com/assets/4687396/7810698/26d5cc7c-03ad-11e5-8047-319d3aa69498.png)
result after fix:
![screen shot 2015-05-26 at 13 32 22](https://cloud.githubusercontent.com/assets/4687396/7810702/2d89a21e-03ad-11e5-9b36-5a0ddf0413f3.png)
