### PR TITLE
ISSUE #12628 Add cc.director.setClearColor for the web engine

### DIFF
--- a/CCBoot.js
+++ b/CCBoot.js
@@ -1943,7 +1943,7 @@ cc._setup = function (el, width, height) {
             'stencil': true,
             'preserveDrawingBuffer': true,
             'antialias': !cc.sys.isMobile,
-            'alpha': false
+            'alpha': true
         });
     if (cc._renderContext) {
         win.gl = cc._renderContext; // global variable declared in CCMacro.js

--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -23,7 +23,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  ****************************************************************************/
-
+ 
 cc.g_NumberOfDraws = 0;
 
 cc.GLToClipTransform = function (transformOut) {
@@ -53,6 +53,7 @@ cc.GLToClipTransform = function (transformOut) {
  *      - setting the OpenGL pixel format (default on is RGB565)<br/>
  *      - setting the OpenGL pixel format (default on is RGB565)<br/>
  *      - setting the OpenGL buffer depth (default one is 0-bit)<br/>
+        - setting the color for clear screen (default one is BLACK)<br/>
  *      - setting the projection (default one is 3D)<br/>
  *      - setting the orientation (default one is Portrait)<br/>
  *      <br/>
@@ -227,7 +228,7 @@ cc.Director = cc.Class.extend(/** @lends cc.Director# */{
             cc.eventManager.dispatchEvent(this._eventAfterUpdate);
         }
 
-        this._clear();
+        renderer.clear();
 
         /* to avoid flickr, nextScene MUST be here: after tick and before draw.
          XXX: Which bug is this one. It seems that it can't be reproduced with v0.9 */
@@ -503,6 +504,15 @@ cc.Director = cc.Class.extend(/** @lends cc.Director# */{
      */
     setDepthTest: null,
 
+    /**
+     * set color for clear screen.<br/>
+     * Implementation can be found in CCDirectorCanvas.js/CCDirectorWebGL.js
+     * @function
+     * @param {cc.color} clearColor
+     */
+    setClearColor: function(clearColor) {
+        cc.renderer._clearColor = clearColor;
+     },
     /**
      * Sets the default values based on the CCConfiguration info
      */
@@ -951,74 +961,3 @@ cc.Director.PROJECTION_CUSTOM = 3;
  * @type {Number}
  */
 cc.Director.PROJECTION_DEFAULT = cc.Director.PROJECTION_3D;
-
-if (cc._renderType === cc._RENDER_TYPE_CANVAS) {
-
-    var _p = cc.Director.prototype;
-
-    _p.setProjection = function (projection) {
-        this._projection = projection;
-        cc.eventManager.dispatchEvent(this._eventProjectionChanged);
-    };
-
-    _p.setDepthTest = function () {
-    };
-
-    _p.setOpenGLView = function (openGLView) {
-        // set size
-        this._winSizeInPoints.width = cc._canvas.width;      //this._openGLView.getDesignResolutionSize();
-        this._winSizeInPoints.height = cc._canvas.height;
-        this._openGLView = openGLView || cc.view;
-        if (cc.eventManager)
-            cc.eventManager.setEnabled(true);
-    };
-
-    _p._clear = function () {
-        var viewport = this._openGLView.getViewPortRect();
-        var context = cc._renderContext.getContext();
-        context.setTransform(1,0,0,1, 0, 0);
-        context.clearRect(-viewport.x, viewport.y, viewport.width, viewport.height);
-    };
-
-    _p._createStatsLabel = function () {
-        var _t = this;
-        var fontSize = 0;
-        if (_t._winSizeInPoints.width > _t._winSizeInPoints.height)
-            fontSize = 0 | (_t._winSizeInPoints.height / 320 * 24);
-        else
-            fontSize = 0 | (_t._winSizeInPoints.width / 320 * 24);
-
-        _t._FPSLabel = new cc.LabelTTF("000.0", "Arial", fontSize);
-        _t._SPFLabel = new cc.LabelTTF("0.000", "Arial", fontSize);
-        _t._drawsLabel = new cc.LabelTTF("0000", "Arial", fontSize);
-
-        var locStatsPosition = cc.DIRECTOR_STATS_POSITION;
-        _t._drawsLabel.setPosition(_t._drawsLabel.width / 2 + locStatsPosition.x, _t._drawsLabel.height * 5 / 2 + locStatsPosition.y);
-        _t._SPFLabel.setPosition(_t._SPFLabel.width / 2 + locStatsPosition.x, _t._SPFLabel.height * 3 / 2 + locStatsPosition.y);
-        _t._FPSLabel.setPosition(_t._FPSLabel.width / 2 + locStatsPosition.x, _t._FPSLabel.height / 2 + locStatsPosition.y);
-    };
-
-    _p.getVisibleSize = function () {
-        //if (this._openGLView) {
-        //return this._openGLView.getVisibleSize();
-        //} else {
-        return this.getWinSize();
-        //}
-    };
-
-    _p.getVisibleOrigin = function () {
-        //if (this._openGLView) {
-        //return this._openGLView.getVisibleOrigin();
-        //} else {
-        return cc.p(0, 0);
-        //}
-    };
-} else {
-    cc.Director._fpsImage = new Image();
-    cc._addEventListener(cc.Director._fpsImage, "load", function () {
-        cc.Director._fpsImageLoaded = true;
-    });
-    if (cc._fpsImage) {
-        cc.Director._fpsImage.src = cc._fpsImage;
-    }
-}

--- a/cocos2d/core/CCDirectorCanvas.js
+++ b/cocos2d/core/CCDirectorCanvas.js
@@ -1,0 +1,90 @@
+/****************************************************************************
+ Copyright (c) 2008-2010 Ricardo Quesada
+ Copyright (c) 2011-2012 cocos2d-x.org
+ Copyright (c) 2013-2014 Chukong Technologies Inc.
+
+ http://www.cocos2d-x.org
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
+
+if (cc._renderType === cc._RENDER_TYPE_CANVAS) {
+
+    var _p = cc.Director.prototype;
+
+    _p.setProjection = function (projection) {
+        this._projection = projection;
+        cc.eventManager.dispatchEvent(this._eventProjectionChanged);
+    };
+
+    _p.setDepthTest = function () {
+    };
+
+    _p.setOpenGLView = function (openGLView) {
+        // set size
+        this._winSizeInPoints.width = cc._canvas.width;      //this._openGLView.getDesignResolutionSize();
+        this._winSizeInPoints.height = cc._canvas.height;
+        this._openGLView = openGLView || cc.view;
+        if (cc.eventManager)
+            cc.eventManager.setEnabled(true);
+    };
+
+    _p._createStatsLabel = function () {
+        var _t = this;
+        var fontSize = 0;
+        if (_t._winSizeInPoints.width > _t._winSizeInPoints.height)
+            fontSize = 0 | (_t._winSizeInPoints.height / 320 * 24);
+        else
+            fontSize = 0 | (_t._winSizeInPoints.width / 320 * 24);
+
+        _t._FPSLabel = new cc.LabelTTF("000.0", "Arial", fontSize);
+        _t._SPFLabel = new cc.LabelTTF("0.000", "Arial", fontSize);
+        _t._drawsLabel = new cc.LabelTTF("0000", "Arial", fontSize);
+
+        var locStatsPosition = cc.DIRECTOR_STATS_POSITION;
+        _t._drawsLabel.setPosition(_t._drawsLabel.width / 2 + locStatsPosition.x, _t._drawsLabel.height * 5 / 2 + locStatsPosition.y);
+        _t._SPFLabel.setPosition(_t._SPFLabel.width / 2 + locStatsPosition.x, _t._SPFLabel.height * 3 / 2 + locStatsPosition.y);
+        _t._FPSLabel.setPosition(_t._FPSLabel.width / 2 + locStatsPosition.x, _t._FPSLabel.height / 2 + locStatsPosition.y);
+    };
+
+    _p.getVisibleSize = function () {
+        //if (this._openGLView) {
+        //return this._openGLView.getVisibleSize();
+        //} else {
+        return this.getWinSize();
+        //}
+    };
+
+    _p.getVisibleOrigin = function () {
+        //if (this._openGLView) {
+        //return this._openGLView.getVisibleOrigin();
+        //} else {
+        return cc.p(0, 0);
+        //}
+    };
+} else {
+    cc.Director._fpsImage = new Image();
+    cc._addEventListener(cc.Director._fpsImage, "load", function () {
+        cc.Director._fpsImageLoaded = true;
+    });
+    if (cc._fpsImage) {
+        cc.Director._fpsImage.src = cc._fpsImage;
+    }
+}

--- a/cocos2d/core/CCDirectorWebGL.js
+++ b/cocos2d/core/CCDirectorWebGL.js
@@ -147,11 +147,6 @@ if (cc._renderType === cc._RENDER_TYPE_WEBGL) {
                 cc.eventManager.setEnabled(true);
         };
 
-        _p._clear = function () {
-            var gl = cc._renderContext;
-            gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        };
-
         _p._beforeVisitScene = function () {
             cc.kmGLPushMatrix();
         };
@@ -314,7 +309,7 @@ if (cc._renderType === cc._RENDER_TYPE_WEBGL) {
             _t.setProjection(_t._projection);
 
             // set other opengl default values
-            cc._renderContext.clearColor(0.0, 0.0, 0.0, 1.0);
+            cc._renderContext.clearColor(0.0, 0.0, 0.0, 0.0);
         };
     })();
 }

--- a/cocos2d/core/renderer/RendererCanvas.js
+++ b/cocos2d/core/renderer/RendererCanvas.js
@@ -32,6 +32,7 @@ cc.rendererCanvas = {
     _cacheToCanvasCmds: {},                              // an array saves the renderer commands need for cache to other canvas
     _cacheInstanceIds: [],
     _currentID: 0,
+    _clearColor: cc.color(),                            //background color,default BLACK
 
     getRenderCmd: function (renderableObject) {
         //TODO Add renderCmd pool here
@@ -123,6 +124,20 @@ cc.rendererCanvas = {
 
     pushDirtyNode: function (node) {
         this._transformNodePool.push(node);
+    },
+
+    clear: function () {
+        var viewport = cc._canvas;
+        var gl = cc._renderContext.getContext();
+        var glWrapper = cc._renderContext;
+        gl.setTransform(1,0,0,1, 0, 0);
+        //IF transparent or translucence clearRect first to decrease filling rate
+        if(this._clearColor['a']!=255)
+            gl.clearRect(0, 0, viewport.width, viewport.height);
+        var fillStyle = 'rgb(' +this._clearColor['r']+','+this._clearColor['g']+','+this._clearColor['b']+')' ;
+        glWrapper.setFillStyle(fillStyle);
+        glWrapper.setGlobalAlpha(this._clearColor['a']);
+        gl.fillRect(0, 0, viewport.width, viewport.height);
     },
 
     clearRenderCommands: function () {

--- a/cocos2d/core/renderer/RendererWebGL.js
+++ b/cocos2d/core/renderer/RendererWebGL.js
@@ -31,6 +31,7 @@ cc.rendererWebGL = {
     _cacheToBufferCmds: {},                              // an array saves the renderer commands need for cache to other canvas
     _cacheInstanceIds: [],
     _currentID: 0,
+    _clearColor: cc.color(),                            //background color,default BLACK
 
     getRenderCmd: function (renderableObject) {
         //TODO Add renderCmd pool here
@@ -117,6 +118,12 @@ cc.rendererWebGL = {
 
     clearRenderCommands: function () {
         this._renderCmds.length = 0;
+    },
+
+    clear: function () {
+        var gl = cc._renderContext;
+        gl.clearColor(this._clearColor['r'], this._clearColor['g'], this._clearColor['b'], this._clearColor['a']);
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
     },
 
     pushRenderCommand: function (cmd) {


### PR DESCRIPTION
This ISSUE sets a new feature setClearColor to web engine, which means set background color of screen.
This feature is supported by both canvas rendering and WebGL rendering.
Separate canvasDirector from Director. 
Enabled transparency for WebGL.