### PR TITLE
Fixed Scale9Sprite setOpacity

### DIFF
--- a/extensions/gui/control-extension/CCScale9Sprite.js
+++ b/extensions/gui/control-extension/CCScale9Sprite.js
@@ -269,12 +269,6 @@ cc.Scale9Sprite = cc.Node.extend(/** @lends cc.Scale9Sprite# */{
         if(!this._scale9Image)
             return;
         cc.Node.prototype.setOpacity.call(this, opacity);
-        var scaleChildren = this._scale9Image.getChildren();
-        for (var i = 0; i < scaleChildren.length; i++) {
-            var selChild = scaleChildren[i];
-            if (selChild)
-                selChild.setOpacity(opacity);
-        }
         this._scale9Dirty = true;
     },
 


### PR DESCRIPTION
Do not propagate opacity to children sprites, in order to avoid multiple opacity levels.
To repro the issue, put on a dark layer a scale9sprite and a stantard sprite loaded with the same texture, then set the opacity to 200. The scale9sprite will be lighter, because of combined opacity of node itself plus children opacity.