### PR TITLE
EditBox now calls EditBoxDelegate::editBoxReturn only when return key is pressed

### DIFF
--- a/extensions/editbox/CCEditBox.js
+++ b/extensions/editbox/CCEditBox.js
@@ -173,7 +173,7 @@ cc.EditBoxDelegate = cc.Class.extend({
     },
 
     /**
-     * This method is called when the return button was pressed or the outside area of keyboard was touched.
+     * This method is called when the return button was pressed.
      * @param {cc.EditBox} sender
      */
     editBoxReturn: function (sender) {
@@ -269,6 +269,8 @@ cc.EditBox = cc.ControlButton.extend({
             if (e.keyCode === cc.KEY.enter) {
                 e.stopPropagation();
                 e.preventDefault();
+                if (selfPointer._delegate && selfPointer._delegate.editBoxReturn)
+                    selfPointer._delegate.editBoxReturn(selfPointer);
                 cc._canvas.focus();
             }
         });
@@ -295,8 +297,6 @@ cc.EditBox = cc.ControlButton.extend({
             }
             if (selfPointer._delegate && selfPointer._delegate.editBoxEditingDidEnd)
                 selfPointer._delegate.editBoxEditingDidEnd(selfPointer);
-            if (selfPointer._delegate && selfPointer._delegate.editBoxReturn)
-                selfPointer._delegate.editBoxReturn(selfPointer);
             cc._canvas.removeEventListener('click', onCanvasClick);
         });
 


### PR DESCRIPTION
Same as https://github.com/cocos2d/cocos2d-x/pull/12849 but for web platform.
Right now, the editBoxEditingDidEnd and editBoxReturn methods are called simultaneously.
This pull request makes editBoxReturn be called only after return key is pressed.