### PR TITLE
cc.ScrollView and cc.TableView: added check for parent visibility in onTouchBegan method

### DIFF
--- a/extensions/gui/scrollview/CCScrollView.js
+++ b/extensions/gui/scrollview/CCScrollView.js
@@ -395,8 +395,10 @@ cc.ScrollView = cc.Layer.extend(/** @lends cc.ScrollView# */{
     /** override functions */
     // optional
     onTouchBegan:function (touch, event) {
-        if (!this.isVisible())
-            return false;
+        for (var c = this; c != null; c = c.parent) {
+            if (!c.isVisible())
+                return false;
+        }
         //var frameOriginal = this.getParent().convertToWorldSpace(this.getPosition());
         //var frame = cc.rect(frameOriginal.x, frameOriginal.y, this._viewSize.width, this._viewSize.height);
         var frame = this._getViewRect();

--- a/extensions/gui/scrollview/CCTableView.js
+++ b/extensions/gui/scrollview/CCTableView.js
@@ -643,8 +643,10 @@ cc.TableView = cc.ScrollView.extend(/** @lends cc.TableView# */{
     },
 
     onTouchBegan:function(touch, event){
-        if (!this.isVisible())
-            return false;
+        for (var c = this; c != null; c = c.parent) {
+            if (!c.isVisible())
+                return false;
+        }
 
         var touchResult = cc.ScrollView.prototype.onTouchBegan.call(this, touch, event);
 


### PR DESCRIPTION
If cc.ScrollView or cc.TableView are added to invisible parent they will still receive touches.
This PR fixes this issue.