### PR TITLE
[ci skip]Fix improper touch intercept event propagation

### DIFF
--- a/extensions/ccui/uiwidgets/scroll-widget/UIListView.js
+++ b/extensions/ccui/uiwidgets/scroll-widget/UIListView.js
@@ -464,6 +464,10 @@ ccui.ListView = ccui.ScrollView.extend(/** @lends ccui.ListView# */{
      */
     interceptTouchEvent: function (eventType, sender, touch) {
         ccui.ScrollView.prototype.interceptTouchEvent.call(this, eventType, sender, touch);
+        if(!this._touchEnabled)
+        {
+            return;
+        }
         if (eventType !== ccui.Widget.TOUCH_MOVED) {
             var parent = sender;
             while (parent) {

--- a/extensions/ccui/uiwidgets/scroll-widget/UIPageView.js
+++ b/extensions/ccui/uiwidgets/scroll-widget/UIPageView.js
@@ -495,6 +495,11 @@ ccui.PageView = ccui.Layout.extend(/** @lends ccui.PageView# */{
      * @param {cc.Touch} touch
      */
     interceptTouchEvent: function (eventType, sender, touch) {
+        if(!this._touchEnabled)
+        {
+            ccui.Layout.prototype.interceptTouchEvent.call(this, eventType, sender, touch);
+            return;
+        }
         var touchPoint = touch.getLocation();
         switch (eventType) {
             case ccui.Widget.TOUCH_BEGAN:

--- a/extensions/ccui/uiwidgets/scroll-widget/UIScrollView.js
+++ b/extensions/ccui/uiwidgets/scroll-widget/UIScrollView.js
@@ -1452,6 +1452,11 @@ ccui.ScrollView = ccui.Layout.extend(/** @lends ccui.ScrollView# */{
      * @param {cc.Touch} touch
      */
     interceptTouchEvent: function (event, sender, touch) {
+        if(!this._touchEnabled)
+        {
+            ccui.Layout.prototype.interceptTouchEvent.call(this, event, sender, touch);
+            return;
+        }
         var touchPoint = touch.getLocation();
         switch (event) {
             case ccui.Widget.TOUCH_BEGAN:


### PR DESCRIPTION
When the container widget is disabled, it shouldn't intercept touch.
Refer to C++ version as #13253(https://github.com/cocos2d/cocos2d-x/pull/13253)
