### PR TITLE
Fixed a bug that bake, setContentScaleFactor can not be used simultan…

### DIFF
--- a/cocos2d/core/sprites/CCBakeSprite.js
+++ b/cocos2d/core/sprites/CCBakeSprite.js
@@ -73,6 +73,6 @@ cc.BakeSprite = cc.Sprite.extend(/** @lends cc.BakeSprite# */{
         if(fillStyle !== locContext._context.fillStyle)
             locContext._context.fillStyle = fillStyle;
         this.getTexture().handleLoadedTexture();
-        this.setTextureRect(cc.rect(0,0, sizeOrWidth, height), false);
+        this.setTextureRect(cc.rect(0,0, sizeOrWidth, height), false, null, false);
     }
 });


### PR DESCRIPTION
…eously

Using both bake and setContentScaleFactor can cause texture size errors.
Because of the _textureCoord, bake and unbake are not the same way.

@pandamicro please review this pr.

因为Sprite的_textureCoord的值默认在bake和unbake的时候不一样。
而bakeSprite应该为一样的值。