### PR TITLE
[ci skip]Optimize ScrollView in WebGL mode

### DIFF
--- a/extensions/ccui/base-classes/UIWidget.js
+++ b/extensions/ccui/base-classes/UIWidget.js
@@ -153,6 +153,7 @@ ccui.Widget = ccui.ProtectedNode.extend(/** @lends ccui.Widget# */{
     _callbackName: null,
     _callbackType: null,
     _usingLayoutComponent: false,
+    _inViewRect: true,
 
     /**
      * Constructor function, override it to extend the construction behavior, remember to call "this._super()" in the extended "ctor" function.


### PR DESCRIPTION
* Avoid visiting and rendering covered nodes in ScrollView in Web Engine.
* only supported in WebGL now but is similar in Canvas  
* Waiting to cut down times to check

@pandamicro 