### PR TITLE
[ci skip] ScrollView Optimizations

### DIFF
--- a/cocos2d/core/renderer/RendererCanvas.js
+++ b/cocos2d/core/renderer/RendererCanvas.js
@@ -142,6 +142,8 @@ cc.rendererCanvas = {
 
     clearRenderCommands: function () {
         this._renderCmds.length = 0;
+        this._cacheInstanceIds.length = 0;
+        this._isCacheToCanvasOn = false;
     },
 
     pushRenderCommand: function (cmd) {

--- a/extensions/ccui/base-classes/UIWidget.js
+++ b/extensions/ccui/base-classes/UIWidget.js
@@ -153,6 +153,7 @@ ccui.Widget = ccui.ProtectedNode.extend(/** @lends ccui.Widget# */{
     _callbackName: null,
     _callbackType: null,
     _usingLayoutComponent: false,
+    _inViewRect: true,
 
     /**
      * Constructor function, override it to extend the construction behavior, remember to call "this._super()" in the extended "ctor" function.

--- a/extensions/ccui/uiwidgets/scroll-widget/UIScrollView.js
+++ b/extensions/ccui/uiwidgets/scroll-widget/UIScrollView.js
@@ -303,13 +303,24 @@ ccui.ScrollView = ccui.Layout.extend(/** @lends ccui.ScrollView# */{
     },
 
     _isInContainer: function (widget) {
-        var top = widget.getBottomBoundary() >= this._customSize.height - this._innerContainer.y;
-        var down = widget.getTopBoundary() <= -this._innerContainer.y;
-        var right = widget.getLeftBoundary() >= this._customSize.width - this._innerContainer.x;
-        var left = widget.getRightBoundary() <= -this._innerContainer.x;
-        if(top || down || right || left)
+        var wPos = widget._position,
+            wSize = widget._contentSize,
+            wAnchor = widget._anchorPoint,
+            size = this._customSize,
+            pos = this._innerContainer._position,
+            bottom = 0, left = 0;
+        if (
+            // Top
+        (bottom = wPos.y - wAnchor.y * wSize.height) >= size.height - pos.y ||
+            // Bottom
+        bottom + wSize.height <= -pos.y ||
+            // right
+        (left = wPos.x - wAnchor.x * wSize.width) >= size.width - pos.x ||
+            // left
+        left + wSize.width <= -pos.x
+        )
             return false;
-        return true;
+        else return true;
     },
 
     updateChildren: function () {

--- a/extensions/ccui/uiwidgets/scroll-widget/UIScrollViewCanvasRenderCmd.js
+++ b/extensions/ccui/uiwidgets/scroll-widget/UIScrollViewCanvasRenderCmd.js
@@ -1,0 +1,43 @@
+(function(){
+    if(!ccui.ProtectedNode.CanvasRenderCmd)
+        return;
+    ccui.ScrollView.CanvasRenderCmd = function(renderable){
+        ccui.Layout.CanvasRenderCmd.call(this, renderable);
+        this._needDraw = true;
+        this._dirty = false;
+    };
+
+    var proto = ccui.ScrollView.CanvasRenderCmd.prototype = Object.create(ccui.Layout.CanvasRenderCmd.prototype);
+    proto.constructor = ccui.ScrollView.CanvasRenderCmd;
+
+    proto.visit = function(parentCmd) {
+        var node = this._node;
+        if (!node._visible)
+            return;
+        cc.renderer.pushRenderCommand(this);
+        var currentID = node.__instanceId;
+        cc.renderer._turnToCacheMode(currentID);
+
+        ccui.Layout.CanvasRenderCmd.prototype.visit.call(this, parentCmd);
+        this._dirtyFlag = 0;
+        cc.renderer._turnToNormalMode();
+    };
+
+    proto.rendering = function (ctx) {
+        var currentID = this._node.__instanceId;
+        var locCmds = cc.renderer._cacheToCanvasCmds[currentID], i, len,
+            scaleX = cc.view.getScaleX(),
+            scaleY = cc.view.getScaleY();
+        var context = ctx || cc._renderContext;
+        context.computeRealOffsetY();
+        
+        for (i = 0, len = locCmds.length; i < len; i++) {
+            var checkNode = locCmds[i]._node;
+            if(checkNode instanceof ccui.ScrollView)
+                continue;
+            if(checkNode && checkNode._parent && checkNode._parent._inViewRect === false)
+                continue;
+            locCmds[i].rendering(context, scaleX, scaleY);
+        }
+    };
+})();

--- a/extensions/ccui/uiwidgets/scroll-widget/UIScrollViewWebGLRenderCmd.js
+++ b/extensions/ccui/uiwidgets/scroll-widget/UIScrollViewWebGLRenderCmd.js
@@ -1,0 +1,44 @@
+
+(function(){
+    if(!ccui.ProtectedNode.WebGLRenderCmd)
+        return;
+    ccui.ScrollView.WebGLRenderCmd = function(renderable){
+        ccui.Layout.WebGLRenderCmd.call(this, renderable);
+        this._needDraw = true;
+        this._dirty = false;
+    };
+
+    var proto = ccui.ScrollView.WebGLRenderCmd.prototype = Object.create(ccui.Layout.WebGLRenderCmd.prototype);
+    proto.constructor = ccui.ScrollView.WebGLRenderCmd;
+
+    proto.visit = function(parentCmd) {
+        var node = this._node;
+        if (!node._visible)
+            return;
+        var currentID = this._node.__instanceId;
+
+        cc.renderer.pushRenderCommand(this);
+        cc.renderer._turnToCacheMode(currentID);
+
+        ccui.Layout.WebGLRenderCmd.prototype.visit.call(this, parentCmd);
+
+        this._dirtyFlag = 0;
+        cc.renderer._turnToNormalMode();
+    };
+
+    proto.rendering = function(ctx){
+        var currentID = this._node.__instanceId;
+        var locCmds = cc.renderer._cacheToBufferCmds[currentID],
+            i,
+            len;
+        var context = ctx || cc._renderContext;
+        for (i = 0, len = locCmds.length; i < len; i++) {
+            var checkNode = locCmds[i]._node;
+            if(checkNode instanceof ccui.ScrollView)
+                continue;
+            if(checkNode && checkNode._parent && checkNode._parent._inViewRect === false)
+                continue;
+            locCmds[i].rendering(context);
+        }
+    }
+})();

--- a/moduleConfig.json
+++ b/moduleConfig.json
@@ -335,7 +335,9 @@
             "extensions/ccui/uiwidgets/UIWebView.js",
             "extensions/ccui/uiwidgets/scroll-widget/UIScrollView.js",
             "extensions/ccui/uiwidgets/scroll-widget/UIListView.js",
-            "extensions/ccui/uiwidgets/scroll-widget/UIPageView.js"
+            "extensions/ccui/uiwidgets/scroll-widget/UIPageView.js",
+            "extensions/ccui/uiwidgets/scroll-widget/UIScrollViewCanvasRenderCmd.js",
+            "extensions/ccui/uiwidgets/scroll-widget/UIScrollViewWebGLRenderCmd.js"
         ],
         "cocostudio" : [
             "core",  "tilemap", "particle", "shape-nodes", "ccui",


### PR DESCRIPTION
* Avoid visiting and rendering covered nodes in ScrollView in Web Engine.
* Works on both WebGL and Canvas
* Waiting to cut down times to check
* previous PR (https://github.com/cocos2d/cocos2d-html5/pull/3084 ),with different methods
* This version is a lot better

@pandamicro 