### PR TITLE
[ci skip] Draw labels directly on Screen instead of creating new canvas

### DIFF
--- a/cocos2d/core/labelttf/CCLabelTTF.js
+++ b/cocos2d/core/labelttf/CCLabelTTF.js
@@ -71,6 +71,7 @@ cc.LabelTTF = cc.Sprite.extend(/** @lends cc.LabelTTF# */{
     _fontSize: 0.0,
     _string: "",
     _originalText: null,
+    _onCacheCanvasMode: false,
 
     // font shadow
     _shadowEnabled: false,
@@ -738,11 +739,21 @@ cc.LabelTTF = cc.Sprite.extend(/** @lends cc.LabelTTF# */{
         cc.Sprite.prototype.setTextureRect.call(this, rect, rotated, untrimmedSize, false);
     },
 
+    /**
+     * set Target to draw on
+     * @param boolean onCanvas
+     */
+    setDrawMode: function (onCacheMode) {
+        this._onCacheCanvasMode = onCacheMode;
+    },
+
     _createRenderCmd: function () {
-        if (cc._renderType === cc._RENDER_TYPE_CANVAS)
-            return new cc.LabelTTF.CanvasRenderCmd(this);
-        else
+        if (cc._renderType === cc._RENDER_TYPE_WEBGL)
             return new cc.LabelTTF.WebGLRenderCmd(this);
+        else if (this._onCacheCanvasMode)
+            return new cc.LabelTTF.CacheCanvasRenderCmd(this);
+        else
+            return new cc.LabelTTF.CanvasRenderCmd(this);
     },
 
     //For web only

--- a/cocos2d/core/labelttf/CCLabelTTF.js
+++ b/cocos2d/core/labelttf/CCLabelTTF.js
@@ -71,7 +71,7 @@ cc.LabelTTF = cc.Sprite.extend(/** @lends cc.LabelTTF# */{
     _fontSize: 0.0,
     _string: "",
     _originalText: null,
-    _onCacheCanvasMode: false,
+    _onCacheCanvasMode: true,
 
     // font shadow
     _shadowEnabled: false,

--- a/cocos2d/core/labelttf/CCLabelTTFWebGLRenderCmd.js
+++ b/cocos2d/core/labelttf/CCLabelTTFWebGLRenderCmd.js
@@ -26,78 +26,10 @@
 (function() {
     cc.LabelTTF.WebGLRenderCmd = function (renderable) {
         cc.Sprite.WebGLRenderCmd.call(this, renderable);
-        cc.LabelTTF.RenderCmd.call(this);
+        cc.LabelTTF.CacheRenderCmd.call(this);
         this.setShaderProgram(cc.shaderCache.programForKey(cc.LabelTTF._SHADER_PROGRAM));
-        this._drawOnCanvas = true;
     };
-
     var proto = cc.LabelTTF.WebGLRenderCmd.prototype = Object.create(cc.Sprite.WebGLRenderCmd.prototype);
-    cc.inject(cc.LabelTTF.RenderCmd.prototype, proto);     //multi-inherit
+    cc.inject(cc.LabelTTF.CacheRenderCmd.prototype, proto);
     proto.constructor = cc.LabelTTF.WebGLRenderCmd;
-
-    proto._setColorsString = function () {
-        this.setDirtyFlag(cc.Node._dirtyFlags.textDirty);
-        var node = this._node;
-        var locStrokeColor = node._strokeColor, locFontFillColor = node._textFillColor,
-            locShadowColor = node._shadowColor || this._displayedColor;
-        this._shadowColorStr = "rgba(" + (0 | locShadowColor.r) + "," + (0 | locShadowColor.g) + "," + (0 | locShadowColor.b) + "," + node._shadowOpacity + ")";
-        this._fillColorStr = "rgba(" + (0 | locFontFillColor.r) + "," + (0 | locFontFillColor.g) + "," + (0 | locFontFillColor.b) + ", 1)";
-        this._strokeColorStr = "rgba(" + (0 | locStrokeColor.r) + "," + (0 | locStrokeColor.g) + "," + (0 | locStrokeColor.b) + ", 1)";
-    };
-
-    proto.updateStatus = function () {
-        var flags = cc.Node._dirtyFlags, locFlag = this._dirtyFlag;
-        var colorDirty = locFlag & flags.colorDirty,
-            opacityDirty = locFlag & flags.opacityDirty;
-
-        if (colorDirty)
-            this._updateDisplayColor();
-        if (opacityDirty)
-            this._updateDisplayOpacity();
-
-        if(colorDirty || opacityDirty){
-            this._setColorsString();
-            this._updateColor();
-            this._updateTexture();
-        }else if(locFlag & flags.textDirty)
-            this._updateTexture();
-
-        if (this._dirtyFlag & flags.transformDirty){
-            this.transform(this.getParentRenderCmd(), true);
-            this._dirtyFlag = this._dirtyFlag & cc.Node._dirtyFlags.transformDirty ^ this._dirtyFlag;
-        }
-    };
-
-    proto._syncStatus = function (parentCmd) {
-        var flags = cc.Node._dirtyFlags, locFlag = this._dirtyFlag;
-        var parentNode = parentCmd ? parentCmd._node : null;
-
-        if(parentNode && parentNode._cascadeColorEnabled && (parentCmd._dirtyFlag & flags.colorDirty))
-            locFlag |= flags.colorDirty;
-
-        if(parentNode && parentNode._cascadeOpacityEnabled && (parentCmd._dirtyFlag & flags.opacityDirty))
-            locFlag |= flags.opacityDirty;
-
-        if(parentCmd && (parentCmd._dirtyFlag & flags.transformDirty))
-            locFlag |= flags.transformDirty;
-
-        var colorDirty = locFlag & flags.colorDirty,
-            opacityDirty = locFlag & flags.opacityDirty;
-
-        this._dirtyFlag = locFlag;
-
-        if (colorDirty)
-            this._syncDisplayColor();
-        if (opacityDirty)
-            this._syncDisplayOpacity();
-
-        if(colorDirty || opacityDirty){
-            this._setColorsString();
-            this._updateColor();
-            this._updateTexture();
-        }else if(locFlag & flags.textDirty)
-            this._updateTexture();
-
-        this.transform(parentCmd);
-    };
 })();

--- a/cocos2d/core/labelttf/CCLabelTTFWebGLRenderCmd.js
+++ b/cocos2d/core/labelttf/CCLabelTTFWebGLRenderCmd.js
@@ -28,6 +28,7 @@
         cc.Sprite.WebGLRenderCmd.call(this, renderable);
         cc.LabelTTF.RenderCmd.call(this);
         this.setShaderProgram(cc.shaderCache.programForKey(cc.LabelTTF._SHADER_PROGRAM));
+        this._drawOnCanvas = true;
     };
 
     var proto = cc.LabelTTF.WebGLRenderCmd.prototype = Object.create(cc.Sprite.WebGLRenderCmd.prototype);


### PR DESCRIPTION
* Avoid drawing creating new `_labelCanvas` to temporarily  store labels.
* In this mode, use `fillText()` instead of `drawImage()`
* use function `setDrawTargetCanvas` to switch between draw on Canvas and Screen.
* Only support on Canvas mode

@VisualSJ  Please help to take a look, thanks!
@pandamicro 