### PR TITLE
Fix ActionTimeline endIndex check

### DIFF
--- a/extensions/cocostudio/timeline/ActionTimeline.js
+++ b/extensions/cocostudio/timeline/ActionTimeline.js
@@ -195,7 +195,7 @@ ccs.ActionTimeline = cc.Action.extend({
             }
         }
         startIndex = num[0];
-        endIndex = num[1] || this._duration;
+        endIndex = num[1] != undefined ? num[1] : this._duration;
         currentFrameIndex = num[2] || startIndex;
         loop = bool!=null ? bool : true;
 


### PR DESCRIPTION
Fix endIndex issue for cocoStudio timeline action for animation with only one frame starting & ending on frame index - 0. 