### PR TITLE
fix loader font bug

### DIFF
--- a/cocos2d/core/platform/CCLoaders.js
+++ b/cocos2d/core/platform/CCLoaders.js
@@ -129,7 +129,15 @@ cc._fontLoader = {
         }else{
             self._loadFont(name, srcs);
         }
-        cb(null, true);
+        if(document.fonts){
+            document.fonts.load("1em " + name).then(function(){
+                cb(null, true);
+            }, function(err){
+                cb(err);
+            });
+        }else{
+            cb(null, true);
+        }
     }
 };
 cc.loader.register(["font", "eot", "ttf", "woff", "svg", "ttc"], cc._fontLoader);


### PR DESCRIPTION
对于自定义字体，可能会出现无效或者刷新之后才生效的问题。原因是字体未加载完毕，因此对于支持document.fonts的浏览器增加判断，加载完毕后再执行cb函数