### PR TITLE
ScrollView visible attribute fix

### DIFF
--- a/extensions/gui/scrollview/CCScrollViewCanvasRenderCmd.js
+++ b/extensions/gui/scrollview/CCScrollViewCanvasRenderCmd.js
@@ -62,6 +62,8 @@
 
     proto.visit = function(parentCmd){
         var node = this._node;
+        if (!node._visible) return;
+        
         var i, locChildren = node._children, childrenLen;
 
         this.transform(parentCmd);


### PR DESCRIPTION
Without my fix, the visible attribute of a ScrollView doesn't work.
Repro steps: just put a scrollview e set visible=false. 