### PR TITLE
[ci skip] Fix improper Renderer Canvas

### DIFF
--- a/cocos2d/core/renderer/RendererCanvas.js
+++ b/cocos2d/core/renderer/RendererCanvas.js
@@ -132,9 +132,9 @@ cc.rendererCanvas = {
         var ctx = cc._renderContext.getContext();
         var wrapper = cc._renderContext;
         ctx.setTransform(1, 0, 0, 1, 0, 0);
-        //IF transparent or translucence clearRect first to decrease filling rate
-        if(this._clearColor.a !== 255)
-            ctx.clearRect(0, 0, viewport.width, viewport.height);
+        //if(this._clearColor.a !== 255)
+        //Canvas Overlap with each other and bold the edge
+        ctx.clearRect(0, 0, viewport.width, viewport.height);
         wrapper.setFillStyle(this._clearFillStyle);
         wrapper.setGlobalAlpha(this._clearColor.a);
         ctx.fillRect(0, 0, viewport.width, viewport.height);


### PR DESCRIPTION
* Fix https://github.com/cocos2d/cocos2d-x/issues/13958
* In CanvasMode, if multiple items overlap with each other, the edge will bold and enhance.
* To avoid this enhance which we do not mean to, clear it ever frame

