### PR TITLE
Fix cascade Color and Opacity for Scale9Sprite

### DIFF
--- a/cocos2d/core/labelttf/CCLabelTTFWebGLRenderCmd.js
+++ b/cocos2d/core/labelttf/CCLabelTTFWebGLRenderCmd.js
@@ -32,4 +32,8 @@
     var proto = cc.LabelTTF.WebGLRenderCmd.prototype = Object.create(cc.Sprite.WebGLRenderCmd.prototype);
     cc.inject(cc.LabelTTF.CacheRenderCmd.prototype, proto);
     proto.constructor = cc.LabelTTF.WebGLRenderCmd;
+    proto._updateColor = function () {
+        this._updateTexture();
+        cc.Sprite.WebGLRenderCmd.prototype._updateColor.call(this);
+    }
 })();

--- a/extensions/ccui/base-classes/UIScale9Sprite.js
+++ b/extensions/ccui/base-classes/UIScale9Sprite.js
@@ -856,13 +856,22 @@ ccui.Scale9Sprite = cc.Scale9Sprite = cc.Node.extend(/** @lends ccui.Scale9Sprit
         var size = originalSize;
 
         this._capInsets = capInsets;
+        var tmpTexture = this._scale9Image.getTexture();
+        var locLoaded = tmpTexture && tmpTexture.isLoaded();
+        this._textureLoaded = locLoaded;
+        if(!locLoaded){
+            tmpTexture.addEventListener("load", function(sender){
+                this._positionsAreDirty = true;
+                this.dispatchEvent("load");
+            },this);
+            return true;
+        }
         if(cc._rectEqualToZero(rect)) {
-            var textureSize = this._scale9Image.getTexture().getContentSize();
+            var textureSize = tmpTexture.getContentSize();
             rect = cc.rect(0, 0, textureSize.width, textureSize.height);
         }
         if(size.width === 0 && size.height === 0)
             size = cc.size(rect.width, rect.height);
-
         this._spriteRect = rect;
         this._offset = offset;
         this._spriteFrameRotated = spriteFrameRotated;
@@ -872,7 +881,7 @@ ccui.Scale9Sprite = cc.Scale9Sprite = cc.Node.extend(/** @lends ccui.Scale9Sprit
         if(this._scale9Enabled)
             this.createSlicedSprites();
         else
-            this._scale9Image.initWithTexture(this._scale9Image.getTexture(), this._spriteRect, this._spriteFrameRotated);
+            this._scale9Image.initWithTexture(tmpTexture, this._spriteRect, this._spriteFrameRotated);
 
         this.setState(this._brightState);
         this.setContentSize(size);
@@ -895,6 +904,17 @@ ccui.Scale9Sprite = cc.Scale9Sprite = cc.Node.extend(/** @lends ccui.Scale9Sprit
         var sprite = new cc.Sprite(batchNode.getTexture());
         var pos = cc.p(0,0);
         var originalSize = cc.size(originalRect.width,originalRect.height);
+
+        var tmpTexture = batchNode.getTexture();
+        var locLoaded = tmpTexture.isLoaded();
+        this._textureLoaded = locLoaded;
+        if(!locLoaded){
+            tmpTexture.addEventListener("load", function(sender){
+                this._positionsAreDirty = true;
+                this.dispatchEvent("load");
+            },this);
+            return true;
+        }
         return this.updateWithSprite(sprite, originalRect, rotated, pos, originalSize, capInsets);
     },
 

--- a/extensions/ccui/base-classes/UIScale9Sprite.js
+++ b/extensions/ccui/base-classes/UIScale9Sprite.js
@@ -855,15 +855,17 @@ ccui.Scale9Sprite = cc.Scale9Sprite = cc.Node.extend(/** @lends ccui.Scale9Sprit
         var rect = spriteRect;
         var size = originalSize;
 
-        this._capInsets = capInsets;
         var tmpTexture = this._scale9Image.getTexture();
         var locLoaded = tmpTexture && tmpTexture.isLoaded();
         this._textureLoaded = locLoaded;
         if(!locLoaded){
             tmpTexture.addEventListener("load", function(sender){
                 this._positionsAreDirty = true;
+                this.updateWithSprite(sprite, spriteRect, spriteFrameRotated, offset, originalSize, capInsets);
+                this.setVisible(true);
                 this.dispatchEvent("load");
-            },this);
+            }, this);
+            this.setVisible(false);
             return true;
         }
         if(cc._rectEqualToZero(rect)) {
@@ -872,6 +874,7 @@ ccui.Scale9Sprite = cc.Scale9Sprite = cc.Node.extend(/** @lends ccui.Scale9Sprit
         }
         if(size.width === 0 && size.height === 0)
             size = cc.size(rect.width, rect.height);
+        this._capInsets = capInsets;
         this._spriteRect = rect;
         this._offset = offset;
         this._spriteFrameRotated = spriteFrameRotated;
@@ -911,8 +914,11 @@ ccui.Scale9Sprite = cc.Scale9Sprite = cc.Node.extend(/** @lends ccui.Scale9Sprit
         if(!locLoaded){
             tmpTexture.addEventListener("load", function(sender){
                 this._positionsAreDirty = true;
+                this.updateWithBatchNode(batchNode, originalRect, rotated, capInsets);
+                this.setVisible(true);
                 this.dispatchEvent("load");
-            },this);
+            }, this);
+            this.setVisible(false);
             return true;
         }
         return this.updateWithSprite(sprite, originalRect, rotated, pos, originalSize, capInsets);

--- a/extensions/ccui/base-classes/UIScale9SpriteWebGLRenderCmd.js
+++ b/extensions/ccui/base-classes/UIScale9SpriteWebGLRenderCmd.js
@@ -104,36 +104,38 @@
 
     };
 
-    proto._updateDisplayColor = function(parentColor){
-        cc.Node.WebGLRenderCmd.prototype._updateDisplayColor.call(this, parentColor);
-
-        var scale9Image = this._node._scale9Image;
-        if(scale9Image){
-            var scaleChildren = scale9Image.getChildren();
-            for (var i = 0; i < scaleChildren.length; i++) {
-                var selChild = scaleChildren[i];
-                if (selChild){
-                    selChild._renderCmd._updateDisplayColor(parentColor);
-                    selChild._renderCmd._updateColor();
-                }
-            }
-        }
+    proto._syncStatus = function (parentCmd){
+        cc.Node.WebGLRenderCmd.prototype._syncStatus.call(this, parentCmd);
+        this._updateDisplayColor(this._node._realColor);
+        this._updateDisplayOpacity(this._displayedOpacity);
     };
 
-    proto._updateDisplayOpacity = function(parentColor){
-        cc.Node.WebGLRenderCmd.prototype._updateDisplayOpacity.call(this, parentColor);
-
-        var scale9Image = this._node._scale9Image;
-        if(scale9Image){
-            var scaleChildren = scale9Image.getChildren();
-            for (var i = 0; i < scaleChildren.length; i++) {
-                var selChild = scaleChildren[i];
-                if (selChild){
-                    selChild._renderCmd._updateDisplayOpacity(parentColor);
-                    selChild._renderCmd._updateColor();
-                }
-            }
+    proto._updateDisplayColor = function(parentColor){
+        cc.Node.WebGLRenderCmd.prototype._updateDisplayColor.call(this, parentColor);
+        var node = this._node;
+        var scale9Image = node._scale9Image;
+        parentColor = node._realColor;
+        if(node._scale9Enabled) {
+            var pChildren = node._renderers;
+            for(var i=0; i<pChildren.length; i++)
+                pChildren[i]._renderCmd._updateColor(parentColor);
         }
+        else
+            scale9Image._renderCmd._updateColor(parentColor);
+    };
+
+    proto._updateDisplayOpacity = function(parentOpacity){
+        cc.Node.WebGLRenderCmd.prototype._updateDisplayOpacity.call(this, parentOpacity);
+        var node = this._node;
+        var scale9Image = node._scale9Image;
+        parentOpacity = this._displayedOpacity;
+        if(node._scale9Enabled) {
+            var pChildren = node._renderers;
+            for(var i=0; i<pChildren.length; i++)
+                pChildren[i]._renderCmd._updateDisplayOpacity(parentOpacity);
+        }
+        else
+            scale9Image._renderCmd._updateDisplayOpacity(parentOpacity);
     };
 
     proto.setState = function (state) {

--- a/extensions/ccui/base-classes/UIScale9SpriteWebGLRenderCmd.js
+++ b/extensions/ccui/base-classes/UIScale9SpriteWebGLRenderCmd.js
@@ -106,7 +106,7 @@
 
     proto._syncStatus = function (parentCmd){
         cc.Node.WebGLRenderCmd.prototype._syncStatus.call(this, parentCmd);
-        this._updateDisplayColor(this._node._realColor);
+        this._updateDisplayColor(this._displayedColor);
         this._updateDisplayOpacity(this._displayedOpacity);
     };
 
@@ -114,14 +114,18 @@
         cc.Node.WebGLRenderCmd.prototype._updateDisplayColor.call(this, parentColor);
         var node = this._node;
         var scale9Image = node._scale9Image;
-        parentColor = node._realColor;
+        parentColor = this._displayedColor;
         if(node._scale9Enabled) {
             var pChildren = node._renderers;
-            for(var i=0; i<pChildren.length; i++)
-                pChildren[i]._renderCmd._updateColor(parentColor);
+            for(var i=0; i<pChildren.length; i++) {
+                pChildren[i]._renderCmd._updateDisplayColor(parentColor);
+                pChildren[i]._renderCmd._updateColor();
+            }
         }
-        else
-            scale9Image._renderCmd._updateColor(parentColor);
+        else {
+            scale9Image._renderCmd._updateDisplayColor(parentColor);
+            scale9Image._renderCmd._updateColor();
+        }
     };
 
     proto._updateDisplayOpacity = function(parentOpacity){


### PR DESCRIPTION
Based on original pr: https://github.com/cocos2d/cocos2d-html5/pull/3127

- An extension to the issue #3103
- Solve cascade problem for ccui.Scale9Sprite under webgl
- Solve cascade opacity issue for cc.LabelTTF under webgl
- Fix texture lazy loading for ccui.Scale9Sprite