### PR TITLE
fix cc.game.config['showFPS'] bug

### DIFF
--- a/CCBoot.js
+++ b/CCBoot.js
@@ -2374,7 +2374,7 @@ cc.game = /** @lends cc.game# */{
             modules = config[CONFIG_KEY.modules];
 
         // Configs adjustment
-        config[CONFIG_KEY.showFPS] = config[CONFIG_KEY.showFPS] || true;
+        config[CONFIG_KEY.showFPS] = typeof config[CONFIG_KEY.showFPS] === 'undefined' ? true : config[CONFIG_KEY.showFPS];
         config[CONFIG_KEY.engineDir] = config[CONFIG_KEY.engineDir] || "frameworks/cocos2d-html5";
         if (config[CONFIG_KEY.debugMode] == null)
             config[CONFIG_KEY.debugMode] = 0;


### PR DESCRIPTION
```javascript
//project.json
{
...
'showFPS' : false,
...
}
```

```javascript
//CCBoot.js
...
config[CONFIG_KEY.showFPS] = config[CONFIG_KEY.showFPS] || true;// this property will be set to true
...
```