### PR TITLE
Add "enableInput" and "disableInput" for CCEditBox.

### DIFF
--- a/extensions/editbox/CCEditBox.js
+++ b/extensions/editbox/CCEditBox.js
@@ -320,6 +320,21 @@ cc.EditBox = cc.ControlButton.extend({
     },
 
     /**
+     * Manuallly enable the focus and input.
+     */
+    enableInput: function(){
+        this._edTxt.removeAttribute("disabled");
+    },
+
+    /**
+     * Manuallly disable the focus and input.
+     */
+    disableInput: function(){
+        this._edTxt.setAttribute("disabled","disabled");
+    }
+    ,
+
+    /**
      * Set the font.
      * @param {String} fontName  The font name.
      * @param {Number} fontSize  The font size.


### PR DESCRIPTION
If the layer with CCEditBox is under another focusing layer or sprite, the CCEditBox could still gain the focus. It is obviously unwanted. Because the CCEditBox is implemented by the dom input, so I add "enableInput" and "disableInput" to manually control the focus logic. I think it should be a quick fix. 