### PR TITLE
Fixed opacity setting of Scale9Sprite

### DIFF
--- a/extensions/ccui/base-classes/UIScale9SpriteWebGLRenderCmd.js
+++ b/extensions/ccui/base-classes/UIScale9SpriteWebGLRenderCmd.js
@@ -128,7 +128,7 @@
         }
     };
 
-    proto._updateDisplayOpacity = function(parentOpacity){
+proto._updateDisplayOpacity = function(parentOpacity){
         cc.Node.WebGLRenderCmd.prototype._updateDisplayOpacity.call(this, parentOpacity);
         var node = this._node;
         var scale9Image = node._scale9Image;
@@ -136,10 +136,16 @@
         if(node._scale9Enabled) {
             var pChildren = node._renderers;
             for(var i=0; i<pChildren.length; i++)
+            {
                 pChildren[i]._renderCmd._updateDisplayOpacity(parentOpacity);
+                pChildren[i]._renderCmd._updateColor();
+            }
         }
         else
+        {
             scale9Image._renderCmd._updateDisplayOpacity(parentOpacity);
+            scale9Image._renderCmd._updateColor();
+        }
     };
 
     proto.setState = function (state) {

--- a/extensions/ccui/base-classes/UIScale9SpriteWebGLRenderCmd.js
+++ b/extensions/ccui/base-classes/UIScale9SpriteWebGLRenderCmd.js
@@ -128,7 +128,7 @@
         }
     };
 
-proto._updateDisplayOpacity = function(parentOpacity){
+    proto._updateDisplayOpacity = function(parentOpacity){
         cc.Node.WebGLRenderCmd.prototype._updateDisplayOpacity.call(this, parentOpacity);
         var node = this._node;
         var scale9Image = node._scale9Image;


### PR DESCRIPTION
I have node with cascade opacity enabled and scale9 sprite on it.
In actions like cc.fadeTo, cc.fadeIn, cc.fadeOut applied to node scale9 sprite doesn't change it's opacity( only after another part of scene is updated).
```javascript
//Some test case
var HelloWorldLayer = ccui.Layout.extend({
    ctor:function () {
        this._super();
    
        this.setCascadeOpacityEnabled(true);

        var sprite = new ccui.Scale9Sprite(res.HelloWorld_png);

        sprite.setPosition(200, 200);

        this.addChild(sprite);

        this.runAction(cc.fadeTo(1, 0));

        return true;
    }
});
```

I have inspected code of **ccui.Scale9Sprite.WebGLRenderCmd** in previous versions of this file and i found that updating of opacity in render cmd must also update color in it's child parts.

Also at the moment this PR completely resolves my issue #3128 .