### PR TITLE
Fixed bug with _setPaused() method

### DIFF
--- a/cocos2d/core/event-manager/CCEventManager.js
+++ b/cocos2d/core/event-manager/CCEventManager.js
@@ -684,6 +684,7 @@ cc.eventManager = /** @lends cc.eventManager# */{
             listener._setSceneGraphPriority(nodeOrPriority);
             listener._setFixedPriority(0);
             listener._setRegistered(true);
+            listener._setPaused(false);
             this._addListener(listener);
         }
 


### PR DESCRIPTION
When I add `cc.EventListener` as SceneGraphPriority, the event doesn't dispatch.

```javascript
cc.eventManager.addListener(listener, someSprite); // This event will not dispatch.
```

I think I found why.

In `CCEventManager.js` find block of code:
```javascript
if (sceneGraphPriorityListeners && !shouldStopPropagation) {    // priority == 0, scene graph priority
    for (j = 0; j < sceneGraphPriorityListeners.length; j++) {
        selListener = sceneGraphPriorityListeners[j];
        // !selListener._isPaused() will always be false
        if (selListener.isEnabled() && !selListener._isPaused() && selListener._isRegistered() && onEvent(selListener, eventOrArgs)) {
            shouldStopPropagation = true;
            break;
        }
    }
}
```

`!selListener._isPaused()` will always be false because when listener is added to `cc.eventManager`, there is not `listener._setPaused(false);` And somehow it is always `true`, when you check by `listener._isPaused()`

Look at `addListener` method in `cc.eventManager`
```javascript
if (cc.isNumber(nodeOrPriority)) {
    if (nodeOrPriority === 0) {
        cc.log(cc._LogInfos.eventManager_addListener);
        return;
    }

    listener._setSceneGraphPriority(null);
    listener._setFixedPriority(nodeOrPriority);
    listener._setRegistered(true);
    listener._setPaused(false);
    this._addListener(listener);
} else {
    listener._setSceneGraphPriority(nodeOrPriority);
    listener._setFixedPriority(0);
    listener._setRegistered(true);
    // Here should be listener._setPaused(false);
    this._addListener(listener);
}
```