### PR TITLE
Fixed _syncStatus of node on opacity updated.

### DIFF
--- a/cocos2d/core/base-nodes/CCNodeCanvasRenderCmd.js
+++ b/cocos2d/core/base-nodes/CCNodeCanvasRenderCmd.js
@@ -353,7 +353,7 @@ cc.Node.RenderCmd.prototype = {
             //update the opacity
             this._syncDisplayOpacity();
 
-        if(colorDirty)
+        if(colorDirty || opacityDirty)
             this._updateColor();
 
         if (cc._renderType === cc.game.RENDER_TYPE_WEBGL || locFlag & flags.transformDirty)


### PR DESCRIPTION
In some cases of updating opacity of node(scene with a lot of sprites and actions, which changes opacity) it doesn't changes. (In WebGL)
I reviewed some code before optimizing of render cmd's and found that in WebGL case in **_syncStatus** function **_updateColor** is called on opacity dirty flag to(not only color dirty flag).
This PR resolves this.(and bug doesn't reproduces)
P.S.
I don't know how exactly reproduce this bug, because i can't found which part of my project causes it.
P.P.S
May be add check if render type is WebGL and call **_updateColor** function if opacity dirty flag set only in case of WebGL?
