### PR TITLE
Fix cc.LabelTTF displays value error

### DIFF
--- a/cocos2d/core/labelttf/CCLabelTTF.js
+++ b/cocos2d/core/labelttf/CCLabelTTF.js
@@ -598,6 +598,8 @@ cc.LabelTTF = cc.Sprite.extend(/** @lends cc.LabelTTF# */{
     _updateString: function () {
         if ((!this._string || this._string === "") && this._string !== this._originalText)
             cc.renderer.childrenOrderDirty = true;
+        if (this._string != null && this._string != "" && this._string !== this._originalText)
+            cc.renderer.childrenOrderDirty = true;
         this._string = this._originalText;
     },
 


### PR DESCRIPTION
 Fix cc.LabelTTF display value error when text != null && text != "" & text != _originalText.