### PR TITLE
fix the TextAtlas incorrect width setting in the ccs file

### DIFF
--- a/extensions/cocostudio/loader/parsers/timelineParser-2.x.js
+++ b/extensions/cocostudio/loader/parsers/timelineParser-2.x.js
@@ -1061,6 +1061,9 @@
         });
         this.widgetAttributes(widget, json);
 
+        // the TextAtlas must be ignore ContentSize[Size] in the ccs file.
+        widget.ignoreContentAdaptWithSize(true);
+
         return widget;
     };
 


### PR DESCRIPTION
after the general widget attributes setting, the width of TextAtlas would be set to a certain value (the num you set in the cocos studio), but in actually we often set the string dynamically and the width of string should be calculating immediately. So enable the ignoreContentSize for the TextAtlas would be the correct way. 