### PR TITLE
Pixelization font issue in canvas mode.

### DIFF
--- a/cocos2d/core/labelttf/CCLabelTTFCanvasRenderCmd.js
+++ b/cocos2d/core/labelttf/CCLabelTTFCanvasRenderCmd.js
@@ -224,7 +224,7 @@ cc.LabelTTF._firsrEnglish = /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôû]/;
         this.drawLabels(context, xOffset, yOffsetArray)
 
         var scale = this._absoluteScale(this._node);
-        scale = Math.max(scale * cc.view.getScaleX(), scale * cc.view.getScaleX());
+        scale = Math.max(scale * cc.view.getScaleX(), scale * cc.view.getScaleY());
 
         this._labelCanvasScale = document.createElement("canvas");
         this._labelCanvasScale.width = context.canvas.width * scale;

--- a/cocos2d/core/sprites/CCSpriteCanvasRenderCmd.js
+++ b/cocos2d/core/sprites/CCSpriteCanvasRenderCmd.js
@@ -150,6 +150,17 @@
         w = locWidth * scaleX;
         h = locHeight * scaleY;
 
+        if (node._fontName && this._labelCanvasScale) {
+            if(node._renderCmd._lastWidth !== w) {
+                node._renderCmd._updateTexture();
+            }
+            sx = 0;
+            sy = 0;
+            sw = this._labelCanvasScale.width;
+            sh = this._labelCanvasScale.height;
+            texture._htmlElementObj = this._labelCanvasScale;
+        }
+
         if (texture) {
             image = texture._htmlElementObj;
             if (texture._pattern !== "") {


### PR DESCRIPTION
This patch fix the pixelization issue that can happen in Cocos2D when the game is upscaled larger than the size defined. It does create an alternate canvas to snapshot the rendered font at 100% of its current size. There might be a cleaner way to implement this but so far it's the best I've come up with.

Node: only works in canvas, same implementation has to be done on the WebGL side.

	modified:   core/labelttf/CCLabelTTFCanvasRenderCmd.js
	modified:   core/sprites/CCSpriteCanvasRenderCmd.js