### PR TITLE
Documentation fixes

### DIFF
--- a/CCBoot.js
+++ b/CCBoot.js
@@ -1894,8 +1894,8 @@ var _initSys = function () {
 };
 _initSys();
 
-delete _tmpCanvas1;
-delete _tmpCanvas2;
+delete window._tmpCanvas1;
+delete window._tmpCanvas2;
 
 //to make sure the cc.log, cc.warn, cc.error and cc.assert would not throw error before init by debugger mode.
 cc.log = cc.warn = cc.error = cc.assert = function () {
@@ -1923,9 +1923,9 @@ function _determineRenderType(config) {
     cc._renderType = cc.game.RENDER_TYPE_CANVAS;
     cc._supportRender = true;
 
-    if ( userRenderMode === 2 || 
-        (   userRenderMode === 0 && 
-            shieldOs.indexOf(cc.sys.os) === -1 && 
+    if ( userRenderMode === 2 ||
+        (   userRenderMode === 0 &&
+            shieldOs.indexOf(cc.sys.os) === -1 &&
             shieldBrowser.indexOf(cc.sys.browserType) === -1 )) {
         if (cc.sys.capabilities["opengl"]) {
             cc._renderType = cc.game.RENDER_TYPE_WEBGL;
@@ -2084,7 +2084,7 @@ cc.game = /** @lends cc.game# */{
         renderMode: "renderMode",
         jsList: "jsList"
     },
-    
+
     // states
     _paused: true,//whether the game is paused
     _prepareCalled: false,//whether the prepare function has been called
@@ -2092,9 +2092,9 @@ cc.game = /** @lends cc.game# */{
     _rendererInitialized: false,
 
     _renderContext: null,
-    
+
     _intervalId: null,//interval target of main
-    
+
     _lastTime: null,
     _frameTime: null,
 
@@ -2207,7 +2207,7 @@ cc.game = /** @lends cc.game# */{
      */
     prepare: function (cb) {
         var self = this,
-            config = self.config, 
+            config = self.config,
             CONFIG_KEY = self.CONFIG_KEY;
 
         this._loadConfig();
@@ -2228,10 +2228,10 @@ cc.game = /** @lends cc.game# */{
             this._initRenderer(config[CONFIG_KEY.width], config[CONFIG_KEY.height]);
 
             /**
+             * cc.view is the shared view object.
              * @type {cc.EGLView}
              * @name cc.view
              * @memberof cc
-             * cc.view is the shared view object.
              */
             cc.view = cc.EGLView._getInstance();
 
@@ -2244,10 +2244,10 @@ cc.game = /** @lends cc.game# */{
             if (cc.director.setOpenGLView)
                 cc.director.setOpenGLView(cc.view);
             /**
+             * cc.winSize is the alias object for the size of the current game window.
              * @type {cc.Size}
              * @name cc.winSize
              * @memberof cc
-             * cc.winSize is the alias object for the size of the current game window.
              */
             cc.winSize = cc.director.getWinSize();
 
@@ -2300,7 +2300,7 @@ cc.game = /** @lends cc.game# */{
                 cc.game.onStart = onStart;
             }
         }
-        
+
         this.prepare(cc.game.onStart && cc.game.onStart.bind(cc.game));
     },
 
@@ -2377,7 +2377,7 @@ cc.game = /** @lends cc.game# */{
         if (document["ccConfig"]) {
             this._initConfig(document["ccConfig"]);
         }
-        // Load from project.json 
+        // Load from project.json
         else {
             try {
                 var cocos_script = document.getElementsByTagName('script');

--- a/CCBoot.js
+++ b/CCBoot.js
@@ -567,8 +567,19 @@ cc.path = /** @lends cc.path# */{
 
 //+++++++++++++++++++++++++something about loader start+++++++++++++++++++++++++++
 /**
- * Loader for resource loading process. It's a singleton object.
+ * Resource loading management. Created by in CCBoot.js as a singleton
+ * cc.loader.
+ * @name cc.Loader
  * @class
+ * @memberof cc
+ * @see cc.loader
+ */
+
+/**
+ * Singleton instance of cc.Loader.
+ * @name cc.loader
+ * @member {cc.Loader}
+ * @memberof cc
  */
 cc.loader = (function () {
     var _jsCache = {}, //cache for js
@@ -607,10 +618,24 @@ cc.loader = (function () {
             "$", "i"
         );
 
-    return /** @lends cc.loader# */{
-        resPath: "",//root path of resource
-        audioPath: "",//root path of audio
-        cache: {},//cache for data loaded
+    return /** @lends cc.Loader# */{
+        /**
+         * Root path of resources.
+         * @type {String}
+         */
+        resPath: "",
+
+        /**
+         * Root path of audio resources
+         * @type {String}
+         */
+        audioPath: "",
+
+        /**
+         * Cache for data loaded.
+         * @type {Object}
+         */
+        cache: {},
 
         /**
          * Get XMLHttpRequest.
@@ -2045,32 +2070,99 @@ cc.initEngine = function (config, cb) {
  * An object to boot the game.
  * @class
  * @name cc.game
+ *
  */
 cc.game = /** @lends cc.game# */{
+	/** 
+	 * Debug mode: No debugging. {@static}
+ 	 * @const {Number}
+	 * @static
+	 */
     DEBUG_MODE_NONE: 0,
+	/**
+     * Debug mode: Info to console.
+	 * @const {Number}
+	 * @static
+     */
     DEBUG_MODE_INFO: 1,
+	/**
+     * Debug mode: Warning to console.
+	 * @const {Number}
+	 * @static
+     */
     DEBUG_MODE_WARN: 2,
+	/**
+     * Debug mode: Error to console.
+	 * @const {Number}
+	 * @static
+     */
     DEBUG_MODE_ERROR: 3,
+	/**
+     * Debug mode: Info to web page.
+	 * @const {Number}
+	 * @static
+     */
     DEBUG_MODE_INFO_FOR_WEB_PAGE: 4,
+	/**
+     * Debug mode: Warning to web page.
+	 * @const {Number}
+	 * @static
+     */
     DEBUG_MODE_WARN_FOR_WEB_PAGE: 5,
+	/**
+     * Debug mode: Error to web page.
+	 * @const {Number}
+	 * @static
+     */
     DEBUG_MODE_ERROR_FOR_WEB_PAGE: 6,
 
+    /**
+     * Event that is fired when the game is hidden.
+     * @constant {String}
+     */
     EVENT_HIDE: "game_on_hide",
+    /**
+     * Event that is fired when the game is shown.
+     * @constant {String}
+     */
     EVENT_SHOW: "game_on_show",
+    /**
+     * Event that is fired when the game is resized.
+     * @constant {String}
+     */
     EVENT_RESIZE: "game_on_resize",
+    /**
+     * Event that is fired when the renderer is done being initialized.
+     * @constant {String}
+     */
     EVENT_RENDERER_INITED: "renderer_inited",
 
+    /** @constant {Number} */
     RENDER_TYPE_CANVAS: 0,
+    /** @constant {Number} */
     RENDER_TYPE_WEBGL: 1,
+    /** @constant {Number} */
     RENDER_TYPE_OPENGL: 2,
 
     _eventHide: null,
     _eventShow: null,
 
     /**
-     * Key of config
+     * Keys found in config.json.
+     *
      * @constant
      * @type {Object}
+     *
+     * @prop {String} width
+     * @prop {String} height
+     * @prop {String} engineDir
+     * @prop {String} modules
+     * @prop {String} debugMode
+     * @prop {String} showFPS
+     * @prop {String} frameRate
+     * @prop {String} id
+     * @prop {String} renderMode
+     * @prop {String} jsList
      */
     CONFIG_KEY: {
         width: "width",
@@ -2122,15 +2214,23 @@ cc.game = /** @lends cc.game# */{
 
     /**
      * Callback when the scripts of engine have been load.
-     * @type {Function}
+     * @type {Function|null}
      */
     onStart: null,
 
     /**
      * Callback when game exits.
-     * @type {Function}
+     * @type {Function|null}
      */
     onStop: null,
+
+    /**
+     * Callback when game frame has been sized or resized. called
+     * once on game startup.
+     *
+     * @type {Function|null}
+     */
+    onResize: null,
 
 //@Public Methods
 

--- a/cocos2d/actions/CCAction.js
+++ b/cocos2d/actions/CCAction.js
@@ -274,7 +274,7 @@ cc.FiniteTimeAction = cc.Action.extend(/** @lends cc.FiniteTimeAction# */{
      * - The reversed action will be x of 100 move to 0.
      * - Will be rewritten
      *
-     * @return {Null}
+     * @return {?cc.Action}
      */
     reverse:function () {
         cc.log("cocos2d: FiniteTimeAction#reverse: Implement me");

--- a/cocos2d/actions/CCActionCamera.js
+++ b/cocos2d/actions/CCActionCamera.js
@@ -100,7 +100,7 @@ cc.ActionCamera = cc.ActionInterval.extend(/** @lends cc.ActionCamera# */{
      * - The action will be x coordinates of 0 move to 100. <br />
      * - The reversed action will be x of 100 move to 0.
      * - Will be rewritten
-     *
+     * @return {?cc.Action}
      */
     reverse:function () {
         return new cc.ReverseTime(this);

--- a/cocos2d/actions/CCActionEase.js
+++ b/cocos2d/actions/CCActionEase.js
@@ -1140,7 +1140,7 @@ cc.EaseElastic = cc.ActionEase.extend(/** @lends cc.EaseElastic# */{
     /**
      * Create a action. Opposite with the original motion trajectory. <br />
      * Will be overwrite.
-     * @return {null}
+     * @return {?cc.Action}
      */
     reverse:function () {
         cc.log("cc.EaseElastic.reverse(): it should be overridden in subclass.");
@@ -3678,4 +3678,3 @@ cc._easeCubicActionInOut = {
 cc.easeCubicActionInOut = function(){
     return cc._easeCubicActionInOut;
 };
-

--- a/cocos2d/actions/CCActionInterval.js
+++ b/cocos2d/actions/CCActionInterval.js
@@ -208,7 +208,7 @@ cc.ActionInterval = cc.FiniteTimeAction.extend(/** @lends cc.ActionInterval# */{
      * returns a reversed action. <br />
      * Will be overwrite.
      *
-     * @return {null}
+     * @return {?cc.Action}
      */
     reverse:function () {
         cc.log("cc.IntervalAction: reverse not implemented.");
@@ -1121,6 +1121,7 @@ cc.RotateTo = cc.ActionInterval.extend(/** @lends cc.RotateTo# */{
     /**
      * RotateTo reverse not implemented.
      * Will be overridden.
+     * @returns {cc.Action}
      */
     reverse:function () {
         cc.log("cc.RotateTo.reverse(): it should be overridden in subclass.");

--- a/cocos2d/actions3d/CCActionGrid.js
+++ b/cocos2d/actions3d/CCActionGrid.js
@@ -56,7 +56,7 @@ cc.GridAction = cc.ActionInterval.extend(/** @lends cc.GridAction# */{
      * to copy object with deep copy.
      * returns a clone of action.
      *
-     * @return {cc.Action}
+     * @return {cc.ActionInterval}
      */
     clone:function(){
         var action = new cc.GridAction();

--- a/cocos2d/audio/CCAudio.js
+++ b/cocos2d/audio/CCAudio.js
@@ -866,7 +866,7 @@ cc.Audio = cc.Class.extend({
 
         /**
          * Pause playing sound effect.
-         * @param {Number} cc.Audio The return value of function playEffect.
+         * @param {Number} audio The return value of function playEffect.
          * @example
          * //example
          * cc.audioEngine.pauseEffect(audioID);
@@ -897,7 +897,7 @@ cc.Audio = cc.Class.extend({
 
         /**
          * Resume playing sound effect.
-         * @param {Number} cc.Audio The return value of function playEffect.
+         * @param {Number} audio The return value of function playEffect.
          * @audioID
          * //example
          * cc.audioEngine.resumeEffect(audioID);
@@ -925,7 +925,7 @@ cc.Audio = cc.Class.extend({
 
         /**
          * Stop playing sound effect.
-         * @param {Number} cc.Audio The return value of function playEffect.
+         * @param {Number} audio The return value of function playEffect.
          * @example
          * //example
          * cc.audioEngine.stopEffect(audioID);

--- a/cocos2d/core/CCCamera.js
+++ b/cocos2d/core/CCCamera.js
@@ -43,7 +43,7 @@
  *     - It is recommended to use it ONLY if you are going to create 3D effects. For 2D effecs, use the action CCFollow or position/scale/rotate. *
  * </p>
  */
-cc.Camera = cc.Class.extend({
+cc.Camera = cc.Class.extend(/** @lends cc.Camera# */{
     _eyeX:null,
     _eyeY:null,
     _eyeZ:null,

--- a/cocos2d/core/CCDirector.js
+++ b/cocos2d/core/CCDirector.js
@@ -23,7 +23,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  ****************************************************************************/
- 
+
 cc.g_NumberOfDraws = 0;
 
 cc.GLToClipTransform = function (transformOut) {
@@ -495,7 +495,7 @@ cc.Director = cc.Class.extend(/** @lends cc.Director# */{
      * set color for clear screen.<br/>
      * Implementation can be found in CCDirectorCanvas.js/CCDirectorWebGL.js
      * @function
-     * @param {cc.color} clearColor
+     * @param {cc.Color} clearColor
      */
     setClearColor: null,
     /**

--- a/cocos2d/core/cocoa/CCGeometry.js
+++ b/cocos2d/core/cocoa/CCGeometry.js
@@ -29,6 +29,9 @@
  * @class cc.Point
  * @param {Number} x
  * @param {Number} y
+ *
+ * @property x {Number}
+ * @property y {Number}
  * @see cc.p
  */
 cc.Point = function (x, y) {
@@ -79,6 +82,8 @@ cc.pointEqualToPoint = function (point1, point2) {
  * @class cc.Size
  * @param {Number} width
  * @param {Number} height
+ * @property {Number} width
+ * @property {Number} height
  * @see cc.size
  */
 cc.Size = function (width, height) {
@@ -127,8 +132,16 @@ cc.sizeEqualToSize = function (size1, size2) {
 /**
  * cc.Rect is the class for rect object, please do not use its constructor to create rects, use cc.rect() alias function instead.
  * @class cc.Rect
+ * @param {Number} x
+ * @param {Number} y
  * @param {Number} width
  * @param {Number} height
+ *
+ * @property {Number} x
+ * @property {Number} y
+ * @property {Number} width
+ * @property {Number} height
+ *
  * @see cc.rect
  */
 cc.Rect = function (x, y, width, height) {
@@ -323,5 +336,3 @@ cc.rectIntersection = function (rectA, rectB) {
     intersection.height = Math.min(cc.rectGetMaxY(rectA), cc.rectGetMaxY(rectB)) - cc.rectGetMinY(intersection);
     return intersection;
 };
-
-

--- a/cocos2d/core/event-manager/CCEventListener.js
+++ b/cocos2d/core/event-manager/CCEventListener.js
@@ -257,7 +257,7 @@ cc.EventListener.KEYBOARD = 3;
  */
 cc.EventListener.MOUSE = 4;
 /**
- * The type code of focus event listener.
+ * The type code of acceleration event listener.
  * @constant
  * @type {number}
  */

--- a/cocos2d/core/platform/CCSAXParser.js
+++ b/cocos2d/core/platform/CCSAXParser.js
@@ -162,8 +162,9 @@ cc.PlistParser = cc.SAXParser.extend(/** @lends cc.plistParser# */{
 
 cc.saxParser = new cc.SAXParser();
 /**
- * @type {cc.PlistParser}
- * @name cc.plistParser
  * A Plist Parser
+ * @type {cc.PlistParser}
+ * @name plistParser
+ * @memberof cc
  */
 cc.plistParser = new cc.PlistParser();

--- a/cocos2d/core/platform/CCTypes.js
+++ b/cocos2d/core/platform/CCTypes.js
@@ -56,8 +56,8 @@ cc.Color = function (r, g, b, a) {
  * Alpha channel is optional. Default value is 255
  *
  * @param {Number|String|cc.Color} r
- * @param {Number} g
- * @param {Number} b
+ * @param {Number} [g]
+ * @param {Number} [b]
  * @param {Number} [a=255]
  * @return {cc.Color}
  */

--- a/cocos2d/core/platform/CCTypesWebGL.js
+++ b/cocos2d/core/platform/CCTypesWebGL.js
@@ -365,7 +365,7 @@ cc.game.addEventListener(cc.game.EVENT_RENDERER_INITED, function () {
     /**
      * @class cc.V3F_C4B_T2F
      * @param {cc.Vertex3F} vertices
-     * @param { cc.color} colors
+     * @param {cc.Color} colors
      * @param {cc.Tex2F} texCoords
      * @param {Array} arrayBuffer
      * @param {Number} offset
@@ -568,7 +568,7 @@ cc.game.addEventListener(cc.game.EVENT_RENDERER_INITED, function () {
     /**
      * @class cc.V2F_C4B_T2F
      * @param {cc.Vertex2F} vertices
-     * @param {cc.color} colors
+     * @param {cc.Color} colors
      * @param {cc.Tex2F} texCoords
      * @param {Array} arrayBuffer
      * @param {Number} offset

--- a/cocos2d/core/sprites/CCSprite.js
+++ b/cocos2d/core/sprites/CCSprite.js
@@ -797,7 +797,7 @@ cc.Sprite = cc.Node.extend(/** @lends cc.Sprite# */{
      * @function
      * @param {cc.Sprite} child
      * @param {Number} localZOrder  child's zOrder
-     * @param {String} [tag] child's tag
+     * @param {number|String} [tag] child's tag
      * @override
      */
     addChild: function (child, localZOrder, tag) {

--- a/cocos2d/core/sprites/CCSprite.js
+++ b/cocos2d/core/sprites/CCSprite.js
@@ -50,7 +50,7 @@
  * @extends cc.Node
  *
  * @param {String|cc.SpriteFrame|HTMLImageElement|cc.Texture2D} fileName  The string which indicates a path to image file, e.g., "scene1/monster.png".
- * @param {cc.Rect} rect  Only the contents inside rect of pszFileName's texture will be applied for this sprite.
+ * @param {cc.Rect} [rect]  Only the contents inside rect of pszFileName's texture will be applied for this sprite.
  * @param {Boolean} [rotated] Whether or not the texture rectangle is rotated.
  * @example
  *

--- a/cocos2d/core/sprites/CCSpriteBatchNode.js
+++ b/cocos2d/core/sprites/CCSpriteBatchNode.js
@@ -576,7 +576,7 @@ cc.SpriteBatchNode = cc.Node.extend(/** @lends cc.SpriteBatchNode# */{
      * Removes all children from the container and do a cleanup all running actions depending on the cleanup parameter. <br/>
      * (override removeAllChildren of cc.Node)
      * @function
-     * @param {Boolean} cleanup
+     * @param {Boolean} [cleanup=true]
      */
     removeAllChildren: function (cleanup) {
         // Invalidate atlas index. issue #569

--- a/cocos2d/core/sprites/CCSpriteFrameCache.js
+++ b/cocos2d/core/sprites/CCSpriteFrameCache.js
@@ -204,10 +204,10 @@ cc.spriteFrameCache = /** @lends cc.spriteFrameCache# */{
      * <p>
      *   Adds multiple Sprite Frames from a plist or json file.<br/>
      *   A texture will be loaded automatically. The texture name will composed by replacing the .plist or .json suffix with .png<br/>
-     *   If you want to use another texture, you should use the addSpriteFrames:texture method.<br/>
+     *   If you want to use another texture, you should use the addSpriteFrames:texture parameter.<br/>
      * </p>
      * @param {String} url file path
-     * @param {HTMLImageElement|cc.Texture2D|string} texture
+     * @param {HTMLImageElement|cc.Texture2D|string} [texture]
      * @example
      * // add SpriteFrames to SpriteFrameCache With File
      * cc.spriteFrameCache.addSpriteFrames(s_grossiniPlist);

--- a/cocos2d/core/support/CCPointExtension.js
+++ b/cocos2d/core/support/CCPointExtension.js
@@ -86,7 +86,7 @@ cc.pMult = function (point, floatVar) {
  * Calculates midpoint between two points.
  * @param {cc.Point} v1
  * @param {cc.Point} v2
- * @return {cc.pMult}
+ * @return {cc.Point}
  */
 cc.pMidpoint = function (v1, v2) {
     return cc.pMult(cc.pAdd(v1, v2), 0.5);
@@ -134,7 +134,7 @@ cc.pRPerp = function (point) {
  * Calculates the projection of v1 over v2.
  * @param {cc.Point} v1
  * @param {cc.Point} v2
- * @return {cc.pMult}
+ * @return {cc.Point}
  */
 cc.pProject = function (v1, v2) {
     return cc.pMult(v2, cc.pDot(v1, v2) / cc.pDot(v2, v2));
@@ -284,7 +284,7 @@ cc.pCompOp = function (p, opFunc) {
  * @param {cc.Point} a
  * @param {cc.Point} b
  * @param {Number} alpha
- * @return {cc.pAdd}
+ * @return {cc.Point}
  */
 cc.pLerp = function (a, b, alpha) {
     return cc.pAdd(cc.pMult(a, 1 - alpha), cc.pMult(b, alpha));
@@ -498,7 +498,7 @@ cc.pSubIn = function(v1, v2) {
 /**
  * adds one point to another (inplace)
  * @param {cc.Point} v1
- * @param {cc.point} v2
+ * @param {cc.Point} v2
  */
 cc.pAddIn = function(v1, v2) {
     v1.x += v2.x;
@@ -512,4 +512,3 @@ cc.pAddIn = function(v1, v2) {
 cc.pNormalizeIn = function(v) {
     cc.pMultIn(v, 1.0 / Math.sqrt(v.x * v.x + v.y * v.y));
 };
-

--- a/cocos2d/kazmath/mat3.js
+++ b/cocos2d/kazmath/mat3.js
@@ -29,6 +29,13 @@
 window.Uint16Array = window.Uint16Array || window.Array;
 window.Float32Array = window.Float32Array || window.Array;
 (function(cc){
+    /**
+     * <p>
+     * A 3x3 matrix                         </br>
+     * </p>
+     * @class
+     * @param {cc.math.Matrix3} [mat3]
+     */
     cc.math.Matrix3 = function(mat3) {
         if (mat3 && mat3.mat) {
             this.mat = new Float32Array(mat3.mat);
@@ -37,9 +44,16 @@ window.Float32Array = window.Float32Array || window.Array;
         }
     };
     cc.kmMat3 = cc.math.Matrix3;
-    var proto = cc.math.Matrix3.prototype;
+    var _p = cc.math.Matrix3.prototype;
 
-    proto.fill = function(mat3) {            //cc.kmMat3Fill
+    /**
+     * Copy matrix.
+     * @fn fill
+     * @memberof cc.math.Matrix3
+     * @param  {cc.math.Matrix3} mat3 Matrix to copy
+     * @return {cc.math.Matrix3} this
+     */
+    _p.fill = function(mat3) {            //cc.kmMat3Fill
         var mat = this.mat, matIn = mat3.mat;
         mat[0] = matIn[0];
         mat[1] = matIn[1];
@@ -53,7 +67,7 @@ window.Float32Array = window.Float32Array || window.Array;
         return this;
     };
 
-    proto.adjugate = function(){   //= cc.kmMat3Adjugate
+    _p.adjugate = function(){   //= cc.kmMat3Adjugate
         var mat = this.mat;
         var m0 = mat[0], m1 = mat[1], m2 = mat[2], m3 = mat[3], m4 = mat[4],
             m5 = mat[5], m6 = mat[6], m7 = mat[7], m8 = mat[8];
@@ -71,7 +85,13 @@ window.Float32Array = window.Float32Array || window.Array;
         return this;
     };
 
-    proto.identity = function() { //cc.kmMat3Identity
+    /**
+     * Sets pOut to an identity matrix returns pOut
+     * @memberof cc.math.Matrix3
+     * @param {cc.math.Matrix3} pOut - A pointer to the matrix to set to identity
+     * @return {cc.math.Matrix3} this
+     */
+    _p.identity = function() { //cc.kmMat3Identity
         var mat = this.mat;
         mat[1] = mat[2] = mat[3] =
             mat[5] = mat[6] = mat[7] = 0;
@@ -81,7 +101,7 @@ window.Float32Array = window.Float32Array || window.Array;
 
     var tmpMatrix = new cc.math.Matrix3();          // internal matrix
 
-    proto.inverse = function(determinate){         //cc.kmMat3Inverse
+    _p.inverse = function(determinate){         //cc.kmMat3Inverse
         if (determinate === 0.0)
             return this;
         tmpMatrix.assignFrom(this);
@@ -91,14 +111,14 @@ window.Float32Array = window.Float32Array || window.Array;
         return this;
     };
 
-    proto.isIdentity = function(){    //= cc.kmMat3IsIdentity
+    _p.isIdentity = function(){    //= cc.kmMat3IsIdentity
         var mat = this.mat;
         return (mat[0] === 1 && mat[1] === 0 && mat[2] === 0
         && mat[3] === 0 && mat[4] === 1 && mat[5] === 0
         && mat[6] === 0 && mat[7] === 0 && mat[8] === 1);
     };
 
-    proto.transpose = function(){     // cc.kmMat3Transpose
+    _p.transpose = function(){     // cc.kmMat3Transpose
         var mat = this.mat;
         var  m1 = mat[1], m2 = mat[2], m3 = mat[3],  m5 = mat[5],
             m6 = mat[6], m7 = mat[7];
@@ -115,7 +135,7 @@ window.Float32Array = window.Float32Array || window.Array;
         return this;
     };
 
-    proto.determinant = function(){
+    _p.determinant = function(){
         var mat = this.mat;
         /*
          calculating the determinant following the rule of sarus,
@@ -130,7 +150,7 @@ window.Float32Array = window.Float32Array || window.Array;
         return output;
     };
 
-    proto.multiply = function(mat3){
+    _p.multiply = function(mat3){
         var m1 = this.mat, m2 = mat3.mat;
         var a0 = m1[0], a1 = m1[1], a2 = m1[2], a3 = m1[3], a4 = m1[4], a5 = m1[5],
             a6 = m1[6], a7 = m1[7], a8 = m1[8];
@@ -151,7 +171,7 @@ window.Float32Array = window.Float32Array || window.Array;
         return this;
     };
 
-    proto.multiplyScalar = function(factor) {
+    _p.multiplyScalar = function(factor) {
         var mat = this.mat;
         mat[0] *= factor;
         mat[1] *= factor;
@@ -185,7 +205,7 @@ window.Float32Array = window.Float32Array || window.Array;
         return retMat;
     };
 
-    proto.assignFrom = function(matIn){      // cc.kmMat3Assign
+    _p.assignFrom = function(matIn){      // cc.kmMat3Assign
         if(this === matIn) {
             cc.log("cc.math.Matrix3.assign(): current matrix equals matIn");
             return this;
@@ -203,7 +223,7 @@ window.Float32Array = window.Float32Array || window.Array;
         return this;
     };
 
-    proto.equals = function(mat3) {
+    _p.equals = function(mat3) {
         if (this === mat3)
             return true;
         var EPSILON = cc.math.EPSILON,m1 = this.mat, m2 = mat3.mat;
@@ -331,14 +351,7 @@ window.Float32Array = window.Float32Array || window.Array;
         return ret;
     };
 
-    proto.rotationToAxisAngle = function() {           //cc.kmMat3RotationToAxisAngle
+    _p.rotationToAxisAngle = function() {           //cc.kmMat3RotationToAxisAngle
         return cc.math.Quaternion.rotationMatrix(this).toAxisAndAngle();
     }
 })(cc);
-
-
-
-
-
-
-

--- a/cocos2d/kazmath/mat4.js
+++ b/cocos2d/kazmath/mat4.js
@@ -37,6 +37,7 @@
      * | 2   6  10  14 |                     </br>
      * | 3   7  11  15 |
      * </p>
+     * @class
      * @param {cc.math.Matrix4} [mat4]
      */
     cc.math.Matrix4 = function (mat4) {
@@ -63,8 +64,8 @@
 
     /**
      * Sets pOut to an identity matrix returns pOut
-     * @Params pOut - A pointer to the matrix to set to identity
-     * @Return Returns pOut so that the call can be nested
+     * @param pOut - A pointer to the matrix to set to identity
+     * @returns Returns pOut so that the call can be nested
      */
     cc.kmMat4Identity = function (pOut) {
         var mat = pOut.mat;
@@ -1008,7 +1009,3 @@
         return temp.toAxisAndAngle();
     };
 })(cc);
-
-
-
-

--- a/cocos2d/kazmath/vec3.js
+++ b/cocos2d/kazmath/vec3.js
@@ -27,7 +27,15 @@
  */
 
 (function(cc) {
-    cc.kmVec3 = cc.math.Vec3 = function (x, y, z) {
+    /**
+     * A 3d vector.
+     * @class
+     * @param {number} [x]
+     * @param {number} [y]
+     * @param {number} [z]
+     */
+
+    cc.math.Vec3 = cc.kmVec3 = function (x, y, z) {
         if(x && y === undefined){
             this.x = x.x;
             this.y = x.y;
@@ -43,9 +51,9 @@
         return new cc.math.Vec3(x, y, z);
     };
 
-    var proto = cc.math.Vec3.prototype;
+    var _p = cc.math.Vec3._ptype;
 
-    proto.fill = function (x, y, z) {    // =cc.kmVec3Fill
+    _p.fill = function (x, y, z) {    // =cc.kmVec3Fill
         if (x && y === undefined) {
             this.x = x.x;
             this.y = x.y;
@@ -58,15 +66,15 @@
         return this;
     };
 
-    proto.length = function () {     //=cc.kmVec3Length
+    _p.length = function () {     //=cc.kmVec3Length
         return Math.sqrt(cc.math.square(this.x) + cc.math.square(this.y) + cc.math.square(this.z));
     };
 
-    proto.lengthSq = function () {   //=cc.kmVec3LengthSq
+    _p.lengthSq = function () {   //=cc.kmVec3LengthSq
         return cc.math.square(this.x) + cc.math.square(this.y) + cc.math.square(this.z)
     };
 
-    proto.normalize = function () {  //= cc.kmVec3Normalize
+    _p.normalize = function () {  //= cc.kmVec3Normalize
         var l = 1.0 / this.length();
         this.x *= l;
         this.y *= l;
@@ -74,7 +82,7 @@
         return this;
     };
 
-    proto.cross = function (vec3) {   //= cc.kmVec3Cross
+    _p.cross = function (vec3) {   //= cc.kmVec3Cross
         var x = this.x, y = this.y, z = this.z;
         this.x = (y * vec3.z) - (z * vec3.y);
         this.y = (z * vec3.x) - (x * vec3.z);
@@ -82,25 +90,25 @@
         return this;
     };
 
-    proto.dot = function (vec) {     //= cc.kmVec3Dot
+    _p.dot = function (vec) {     //= cc.kmVec3Dot
         return (  this.x * vec.x + this.y * vec.y + this.z * vec.z );
     };
 
-    proto.add = function(vec){      //= cc.kmVec3Add
+    _p.add = function(vec){      //= cc.kmVec3Add
         this.x += vec.x;
         this.y += vec.y;
         this.z += vec.z;
         return this;
     };
 
-    proto.subtract = function (vec) {  // = cc.kmVec3Subtract
+    _p.subtract = function (vec) {  // = cc.kmVec3Subtract
         this.x -= vec.x;
         this.y -= vec.y;
         this.z -= vec.z;
         return this;
     };
 
-    proto.transform = function (mat4) {             // = cc.kmVec3Transform
+    _p.transform = function (mat4) {             // = cc.kmVec3Transform
         var x = this.x, y = this.y, z = this.z, mat = mat4.mat;
         this.x = x * mat[0] + y * mat[4] + z * mat[8] + mat[12];
         this.y = x * mat[1] + y * mat[5] + z * mat[9] + mat[13];
@@ -108,7 +116,7 @@
         return this;
     };
 
-    proto.transformNormal = function(mat4){
+    _p.transformNormal = function(mat4){
         /*
          a = (Vx, Vy, Vz, 0)
          b = (a×M)T
@@ -122,7 +130,7 @@
         return this;
     };
 
-    proto.transformCoord = function(mat4){        // = cc.kmVec3TransformCoord
+    _p.transformCoord = function(mat4){        // = cc.kmVec3TransformCoord
         /*
          a = (Vx, Vy, Vz, 1)
          b = (a×M)T
@@ -136,21 +144,21 @@
         return this;
     };
 
-    proto.scale = function(scale){             // = cc.kmVec3Scale
+    _p.scale = function(scale){             // = cc.kmVec3Scale
         this.x *= scale;
         this.y *= scale;
         this.z *= scale;
         return this;
     };
 
-    proto.equals = function(vec){    // = cc.kmVec3AreEqual
+    _p.equals = function(vec){    // = cc.kmVec3AreEqual
         var EPSILON = cc.math.EPSILON;
         return (this.x < (vec.x + EPSILON) && this.x > (vec.x - EPSILON)) &&
             (this.y < (vec.y + EPSILON) && this.y > (vec.y - EPSILON)) &&
             (this.z < (vec.z + EPSILON) && this.z > (vec.z - EPSILON));
     };
 
-    proto.inverseTransform = function(mat4){   //= cc.kmVec3InverseTransform
+    _p.inverseTransform = function(mat4){   //= cc.kmVec3InverseTransform
         var mat = mat4.mat;
         var v1 = new cc.math.Vec3(this.x - mat[12], this.y - mat[13], this.z - mat[14]);
         this.x = v1.x * mat[0] + v1.y * mat[1] + v1.z * mat[2];
@@ -159,7 +167,7 @@
         return this;
     };
 
-    proto.inverseTransformNormal = function(mat4){   // = cc.kmVec3InverseTransformNormal
+    _p.inverseTransformNormal = function(mat4){   // = cc.kmVec3InverseTransformNormal
         var x = this.x, y = this.y, z = this.z, mat = mat4.mat;
         this.x = x * mat[0] + y * mat[1] + z * mat[2];
         this.y = x * mat[4] + y * mat[5] + z * mat[6];
@@ -167,7 +175,7 @@
         return this;
     };
 
-    proto.assignFrom = function(vec){
+    _p.assignFrom = function(vec){
         if(!vec)
             return this;
         this.x = vec.x;
@@ -181,7 +189,7 @@
         return vec;
     };
 
-    proto.toTypeArray = function(){           //cc.kmVec3ToTypeArray
+    _p.toTypeArray = function(){           //cc.kmVec3ToTypeArray
         var tyArr = new Float32Array(3);
         tyArr[0] = this.x;
         tyArr[1] = this.y;
@@ -189,13 +197,3 @@
         return tyArr;
     };
 })(cc);
-
-
-
-
-
-
-
-
-
-

--- a/cocos2d/menus/CCMenu.js
+++ b/cocos2d/menus/CCMenu.js
@@ -51,7 +51,7 @@ cc.DEFAULT_PADDING = 5;
  *  - But the only accepted children are MenuItem objects</p>
  * @class
  * @extends cc.Layer
- * @param {...cc.MenuItem|null} menuItems}
+ * @param {...cc.MenuItem|null} menuItems
  * @example
  * var layer = new cc.Menu(menuitem1, menuitem2, menuitem3);
  */

--- a/cocos2d/menus/CCMenuItem.js
+++ b/cocos2d/menus/CCMenuItem.js
@@ -338,7 +338,7 @@ cc.MenuItemLabel = cc.MenuItem.extend(/** @lends cc.MenuItemLabel# */{
     },
     /**
      * return the string of cc.MenuItemLabel
-     * @returns {*|string|_p.string|ret.string|q.string|String}
+     * @returns {String}
      */
     getString: function () {
         return this._label.string;
@@ -739,7 +739,7 @@ cc.MenuItemSprite = cc.MenuItem.extend(/** @lends cc.MenuItemSprite# */{
         if (this._normalImage) {
             this.removeChild(this._normalImage, true);
         }
-        
+
         this._normalImage = normalImage;
         if(!this._normalImage)
             return;
@@ -1211,9 +1211,9 @@ cc.MenuItemToggle = cc.MenuItem.extend(/** @lends cc.MenuItemToggle# */{
 
     /**
      * initializes a cc.MenuItemToggle with items
-     * @param {cc.MenuItem} args[0...last-2] the rest in the array are cc.MenuItems
-     * @param {function|String} args[last-1] the second item in the args array is the callback
-     * @param {cc.Node} args[last] the first item in the args array is a target
+     * @param {...cc.MenuItem} array the rest in the array are cc.MenuItems
+     * @param {function|String} secondTolast the second item in the args array is the callback
+     * @param {cc.Node} last the first item in the args array is a target
      * @return {Boolean}
      */
     initWithItems: function (args) {
@@ -1338,7 +1338,6 @@ cc.defineGetterSetter(_p, "selectedIndex", _p.getSelectedIndex, _p.setSelectedIn
  * The inner items can be any MenuItem
  * @deprecated since v3.0 please use new cc.MenuItemToggle(params) instead
  * @return {cc.MenuItemToggle}
- * @example
  */
 cc.MenuItemToggle.create = function (/*Multiple arguments follow*/) {
     if ((arguments.length > 0) && (arguments[arguments.length - 1] == null))

--- a/cocos2d/node-grid/CCNodeGrid.js
+++ b/cocos2d/node-grid/CCNodeGrid.js
@@ -33,7 +33,7 @@
  * @property {cc.GridBase}  grid    - Grid object that is used when applying effects
  * @property {cc.Node}      target  - <@writeonly>Target
  */
-cc.NodeGrid = cc.Node.extend({
+cc.NodeGrid = cc.Node.extend(/** @lends cc.NodeGrid# */{
     grid: null,
     _target: null,
     _gridRect:null,
@@ -61,14 +61,14 @@ cc.NodeGrid = cc.Node.extend({
 
     /**
      * @brief Set the effect grid rect.
-     * @param {cc.rect} rect.
+     * @param {cc.Rect} rect
      */
     setGridRect: function (rect) {
         this._gridRect = rect;
     },
     /**
      * @brief Get the effect grid rect.
-     * @return {cc.rect} rect.
+     * @return {cc.Rect} rect.
     */
     getGridRect: function () {
         return this._gridRect;

--- a/cocos2d/parallax/CCParallaxNode.js
+++ b/cocos2d/parallax/CCParallaxNode.js
@@ -200,7 +200,7 @@ cc.ParallaxNode = cc.Node.extend(/** @lends cc.ParallaxNode# */{
 
     /**
      *  Remove all children with cleanup
-     * @param {Boolean} cleanup
+     * @param {Boolean} [cleanup=true]
      */
     removeAllChildren:function (cleanup) {
         this.parallaxArray.length = 0;

--- a/cocos2d/particle/CCParticleBatchNode.js
+++ b/cocos2d/particle/CCParticleBatchNode.js
@@ -311,7 +311,7 @@ cc.ParticleBatchNode = cc.Node.extend(/** @lends cc.ParticleBatchNode# */{
     },
 
     /**
-     * @param {Boolean} doCleanup
+     * @param {Boolean} [doCleanup=true]
      */
     removeAllChildren:function (doCleanup) {
         var locChildren = this._children;

--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -204,7 +204,7 @@ cc.Particle.TemporaryPoints = [
  * @property {Number}               positionType        - Particles movement type: cc.ParticleSystem.TYPE_FREE | cc.ParticleSystem.TYPE_GROUPED.
  * @property {Number}               totalParticles      - Maximum particles of the system.
  * @property {Boolean}              autoRemoveOnFinish  - Indicate whether the node will be auto-removed when it has no particles left.
- * @property {cc.Texture2D}         texture             - Texture of Particle System.
+ * @property {cc.Texture2D|HTMLImageElement|HTMLCanvasElement}         texture             - Texture of Particle System.
  *
  * @example
  *  emitter.radialAccel = 15;

--- a/cocos2d/physics/CCPhysicsSprite.js
+++ b/cocos2d/physics/CCPhysicsSprite.js
@@ -410,6 +410,9 @@
                 return new cc.PhysicsSprite.WebGLRenderCmd(this);
         }
     };
+    /**
+     * @class
+     */
     cc.PhysicsSprite = cc.Sprite.extend(chipmunkAPI);
     cc.PhysicsSprite._className = "PhysicsSprite";
     var _p = cc.PhysicsSprite.prototype;

--- a/cocos2d/shaders/CCGLStateCache.js
+++ b/cocos2d/shaders/CCGLStateCache.js
@@ -187,7 +187,7 @@ cc.setProjectionMatrixDirty = function () {
  *    These flags can be ORed. The flags that are not present, will be disabled.
  * </p>
  * @function
- * @param {cc.VERTEX_ATTRIB_FLAG_POSITION | cc.VERTEX_ATTRIB_FLAG_COLOR | cc.VERTEX_ATTRIB_FLAG_TEX_OORDS} flags
+ * @param {cc.VERTEX_ATTRIB_FLAG_POSITION | cc.VERTEX_ATTRIB_FLAG_COLOR | cc.VERTEX_ATTRIB_FLAG_TEX_COORDS} flags
  */
 cc.glEnableVertexAttribs = function (flags) {
     /* Position */
@@ -337,4 +337,3 @@ cc.glEnable = function (flags) {
          cc._renderContext.disable(cc._renderContext.BLEND);*/
     }
 };
-

--- a/cocos2d/shape-nodes/CCDrawNode.js
+++ b/cocos2d/shape-nodes/CCDrawNode.js
@@ -83,7 +83,7 @@ cc.__t = function (v) {
 /**
  * <p>CCDrawNode                                                <br/>
  * Node that draws dots, segments and polygons.                        <br/>
- * Faster than the "drawing primitives" since they it draws everything in one single batch.</p>
+ * Faster than the "drawing primitives" since it draws everything in one single batch.</p>
  * @class
  * @name cc.DrawNode
  * @extends cc.Node
@@ -158,7 +158,7 @@ cc.DrawNode = cc.Node.extend(/** @lends cc.DrawNode# */{
 
 /**
  * Creates a DrawNode
- * @deprecated since v3.0 please use new cc.DrawNode() instead.
+ * @deprecated since v3.0 please use `new cc.DrawNode()` instead.
  * @return {cc.DrawNode}
  */
 cc.DrawNode.create = function () {
@@ -351,8 +351,8 @@ cc.game.addEventListener(cc.game.EVENT_RENDERER_INITED, function () {
              * @override
              * @param {Array} points
              * @param {Number} segments
-             * @param {Number} lineWidth
-             * @param {cc.Color} color
+             * @param {Number} [lineWidth]
+             * @param {cc.Color} [color]
              */
             drawCatmullRom: function (points, segments, lineWidth, color) {
                 this.drawCardinalSpline(points, 0.5, segments, lineWidth, color);
@@ -364,8 +364,8 @@ cc.game.addEventListener(cc.game.EVENT_RENDERER_INITED, function () {
              * @param {Array} config
              * @param {Number} tension
              * @param {Number} segments
-             * @param {Number} lineWidth
-             * @param {cc.Color} color
+             * @param {Number} [lineWidth]
+             * @param {cc.Color} [color]
              */
             drawCardinalSpline: function (config, tension, segments, lineWidth, color) {
                 lineWidth = lineWidth || this._lineWidth;
@@ -408,7 +408,7 @@ cc.game.addEventListener(cc.game.EVENT_RENDERER_INITED, function () {
              * draw a dot at a position, with a given radius and color
              * @param {cc.Point} pos
              * @param {Number} radius
-             * @param {cc.Color} color
+             * @param {cc.Color} [color]
              */
             drawDot: function (pos, radius, color) {
                 color = color || this.getDrawColor();
@@ -426,7 +426,7 @@ cc.game.addEventListener(cc.game.EVENT_RENDERER_INITED, function () {
              * @override
              * @param {Array} points point of array
              * @param {Number} radius
-             * @param {cc.Color} color
+             * @param {cc.Color} [color]
              */
             drawDots: function(points, radius, color){
                 if(!points || points.length == 0)
@@ -442,8 +442,8 @@ cc.game.addEventListener(cc.game.EVENT_RENDERER_INITED, function () {
              * draw a segment with a radius and color
              * @param {cc.Point} from
              * @param {cc.Point} to
-             * @param {Number} lineWidth
-             * @param {cc.Color} color
+             * @param {Number} [lineWidth]
+             * @param {cc.Color} [color]
              */
             drawSegment: function (from, to, lineWidth, color) {
                 lineWidth = lineWidth || this._lineWidth;
@@ -462,9 +462,9 @@ cc.game.addEventListener(cc.game.EVENT_RENDERER_INITED, function () {
             /**
              * draw a polygon with a fill color and line color without copying the vertex list
              * @param {Array} verts
-             * @param {cc.Color} fillColor
-             * @param {Number} lineWidth
-             * @param {cc.Color} color
+             * @param {cc.Color|null} fillColor Fill color or `null` for a hollow polygon.
+             * @param {Number} [lineWidth]
+             * @param {cc.Color} [color]
              */
             drawPoly_: function (verts, fillColor, lineWidth, color) {
                 lineWidth = (lineWidth == null ) ? this._lineWidth : lineWidth;
@@ -472,7 +472,7 @@ cc.game.addEventListener(cc.game.EVENT_RENDERER_INITED, function () {
                 if (color.a == null)
                     color.a = 255;
                 var element = new cc._DrawNodeElement(cc.DrawNode.TYPE_POLY);
-                
+
                 element.verts = verts;
                 element.fillColor = fillColor;
                 element.lineWidth = lineWidth;
@@ -484,20 +484,20 @@ cc.game.addEventListener(cc.game.EVENT_RENDERER_INITED, function () {
                     element.isFill = true;
                 this._buffer.push(element);
             },
-            
+
             /**
              * draw a polygon with a fill color and line color, copying the vertex list
              * @param {Array} verts
-             * @param {cc.Color} fillColor
-             * @param {Number} lineWidth
-             * @param {cc.Color} color
+             * @param {cc.Color|null} fillColor Fill color or `null` for a hollow polygon.
+             * @param {Number} [lineWidth]
+             * @param {cc.Color} [lineColor]
              */
-            drawPoly: function (verts, fillColor, lineWidth, color) {
+            drawPoly: function (verts, fillColor, lineWidth, lineColor) {
                 var vertsCopy = [];
                 for (var i=0; i < verts.length; i++) {
                     vertsCopy.push(cc.p(verts[i].x, verts[i].y));
                 }
-                return this.drawPoly_(vertsCopy, fillColor, lineWidth, color);     
+                return this.drawPoly_(vertsCopy, fillColor, lineWidth, lineColor);
             },
 
             /**
@@ -513,7 +513,7 @@ cc.game.addEventListener(cc.game.EVENT_RENDERER_INITED, function () {
         });
     }
     else if (cc._renderType === cc.game.RENDER_TYPE_WEBGL) {
-        
+
         cc.extend(cc.DrawNode.prototype, {
             _bufferCapacity:0,
 

--- a/cocos2d/transitions/CCTransitionProgress.js
+++ b/cocos2d/transitions/CCTransitionProgress.js
@@ -65,8 +65,8 @@ cc.TransitionProgress = cc.TransitionScene.extend(/** @lends cc.TransitionProgre
 	},
 
     /**
+     * Custom on enter.
      * @override
-     * custom on enter
      */
     onEnter:function () {
         cc.TransitionScene.prototype.onEnter.call(this);
@@ -107,8 +107,8 @@ cc.TransitionProgress = cc.TransitionScene.extend(/** @lends cc.TransitionProgre
     },
 
     /**
-     * @override
      * custom on exit
+     * @override
      */
     onExit:function () {
         // remove our layer and release all containing objects
@@ -425,7 +425,7 @@ cc.TransitionProgressOutIn = cc.TransitionProgress.extend(/** @lends cc.Transiti
         cc.TransitionProgress.prototype.ctor.call(this);
         scene && this.initWithDuration(t, scene);
     },
-    
+
     _progressTimerNodeWithRenderTexture:function (texture) {
         var size = cc.director.getWinSize();
         var pNode = new cc.ProgressTimer(texture.sprite);

--- a/jsb_apis.js
+++ b/jsb_apis.js
@@ -93,7 +93,7 @@ jsb.fileUtils = /** @lends jsb.fileUtils# */{
      * @param {String} arg2
      * @return {bool}
      */
-    renameFile : function (str, str, str)
+    renameFile : function (arg0,arg1,arg2)
     {
         return false;
     },
@@ -189,7 +189,7 @@ jsb.fileUtils = /** @lends jsb.fileUtils# */{
      * @param {String} arg1
      * @return {bool}
      */
-    writeStringToFile : function (str, str)
+    writeStringToFile : function (arg0,arg1)
     {
         return false;
     },
@@ -241,7 +241,7 @@ jsb.fileUtils = /** @lends jsb.fileUtils# */{
      * @param {String} arg1
      * @return {String}
      */
-    fullPathFromRelativeFile : function (str, str)
+    fullPathFromRelativeFile : function (arg0,arg1)
     {
         return ;
     },
@@ -363,7 +363,7 @@ jsb.EventAssetsManager = cc.Class.extend(/** @lends jsb.EventAssetsManager# */{
 
     /**
      * @function getEventCode
-     * @return {cc.EventAssetsManager::EventCode}
+     * @return {number} cc.EventAssetsManager.EventCode
      */
     getEventCode : function (
         )
@@ -386,7 +386,7 @@ jsb.EventAssetsManager = cc.Class.extend(/** @lends jsb.EventAssetsManager# */{
      * @constructor
      * @param {String} arg0
      * @param {cc.AssetsManager} arg1
-     * @param {cc.EventAssetsManager::EventCode} arg2
+     * @param {number} arg2 cc.EventAssetsManager::EventCode
      * @param {float} arg3
      * @param {float} arg4
      * @param {String} arg5
@@ -395,15 +395,15 @@ jsb.EventAssetsManager = cc.Class.extend(/** @lends jsb.EventAssetsManager# */{
      * @param {int} arg8
      */
     EventAssetsManager : function (
-        str,
+        arg0,
         assetsmanager,
         eventcode,
-        float,
-        float,
-        str,
-        str,
-        int,
-        int
+        arg3,
+        arg4,
+        arg5,
+        arg6,
+        arg7,
+        arg8
         )
     {
     }
@@ -464,7 +464,7 @@ jsb.AssetsManager = cc.Class.extend(/** @lends jsb.AssetsManager# */{
 
     /**
      * @function getState
-     * @return {jsb.AssetsManager::State}
+     * @return {number} jsb.AssetsManager::State
      */
     getState : function ()
     {
@@ -496,7 +496,7 @@ jsb.AssetsManager = cc.Class.extend(/** @lends jsb.AssetsManager# */{
 
     /**
      * @function getLocalManifest
-     * @return {jsb.Manifest}
+     * @return {object} jsb.Manifest
      */
     getLocalManifest : function ()
     {
@@ -525,7 +525,7 @@ jsb.AssetsManager = cc.Class.extend(/** @lends jsb.AssetsManager# */{
      * @param {String} arg1
      * @return {jsb.AssetsManager}
      */
-    create : function (str, str)
+    create : function (arg0,arg1)
     {
         return cc.AssetsManager;
     },
@@ -536,7 +536,7 @@ jsb.AssetsManager = cc.Class.extend(/** @lends jsb.AssetsManager# */{
      * @param {String} arg0
      * @param {String} arg1
      */
-    ctor : function (str, str)
+    ctor : function (arg0,arg1)
     {
     }
 


### PR DESCRIPTION
A whole pile of (mostly? I'm hoping?) non-controversial documentation fixes.

I am running jsdoc 3.0 on the doc tree to produce a FlowType declaration file (for static type analysis of JavaScript code). The docs are actually quite awesome in how much information they provide; considering how much of the documentation Just Worked, this really isn't that many bugs.

Some of the changes were because FlowType threw an error because an inherited class member function signature didn't match the signature of the same function in an ancestor class. Many of the changes were just random typos. A couple of changes (like delete window._tmpCanvas1 in CCBoot) were because jsdoc 3.0 was throwing an error and wouldn't read the file without the fix. You should take a look at the jsdoc 3.0 output, by the way; it's very nice.

I may have other similar pull requests in the future as I use Cocos2d/html more, and I find more of the documentation that needs to be fixed. In general I think this will just help the docs.

Let me know if you want me to actually submit *text* documentation changes. I could probably be encouraged to document bits of the code as I use them. I wrote an entire 500+ page book on an older (now dead) game SDK using Doxygen/JavaDoc style docs, just documenting things as I went, so it's become a bit of a habit.

(cherry picked from commit ec063969a972cfb27ce57ab47255a65ea48c4d81)
(cherry picked from commit a9909bbccbbe60516412660d48393a30ba1eb920)
(cherry picked from commit 4a1839fff8a8c36e7ccaa2f48597a2e527520e3f)
(cherry picked from commit 552608743837ab64c3b49e8bcd363a249ce578da)
(cherry picked from commit 543b8914c79a00d3303070045f25b6614c849baa)
(cherry picked from commit 94ee8d9fbce7326617edc7d48352b388a1bee628)