### PR TITLE
Fix SpriteFrame to work with scaled textures

### DIFF
--- a/cocos2d/core/sprites/CCSpriteFrame.js
+++ b/cocos2d/core/sprites/CCSpriteFrame.js
@@ -347,8 +347,8 @@ cc.SpriteFrame = cc.Class.extend(/** @lends cc.SpriteFrame# */{
         texture = this.getTexture();
 
         this._rectInPixels = rect;
-        rect = this._rect = cc.rectPixelsToPoints(rect);
-        
+        this._rect = cc.rectPixelsToPoints(rect);
+
         if(texture && texture.url && texture.isLoaded()) {
             var _x, _y;
             if(rotated){


### PR DESCRIPTION
When adding a sprite frame with a scale of <1, the coordinates of the sprite rectangle will (correctly) be larger than the size of the source image. The current code will throw an assert when the scaled size is larger. The fix is to check the image size against the pixel dimensions, not the scaled dimensions.

(cherry picked from commit 8f04485a2e938eba0d90ebbd7e3d1adc97cccfe9)