### PR TITLE
Warn if we retrieve size of texture not loaded

### DIFF
--- a/cocos2d/core/textures/CCTexture2D.js
+++ b/cocos2d/core/textures/CCTexture2D.js
@@ -136,6 +136,9 @@ cc.game.addEventListener(cc.game.EVENT_RENDERER_INITED, function () {
              */
             getContentSize: function () {
                 var locScaleFactor = cc.contentScaleFactor();
+                if (!this._textureLoaded) {
+                    cc.warn("Texture " + this.url + " is not available yet");
+                }
                 return cc.size(this._contentSize.width / locScaleFactor, this._contentSize.height / locScaleFactor);
             },
 
@@ -151,6 +154,9 @@ cc.game.addEventListener(cc.game.EVENT_RENDERER_INITED, function () {
              * @returns {cc.Size}
              */
             getContentSizeInPixels: function () {
+                if (!this._textureLoaded) {
+                    cc.warn("Texture " + this.url + " is not available yet");
+                }
                 return this._contentSize;
             },
 


### PR DESCRIPTION
While playing with TileMap, I've encountered a case where
I loaded a TMX file from preloaded resource (without
image). Image was not yet loaded and size (0, 0) was saved
in cc.TMXTilesetInfo.imageSize: method rectForGID() miscompute
invalid rect source.
At render time, first tile was used to render everything.
This commit emit a warning that a texture is used before loaded.
