### PR TITLE
Refactor using of stencil clipping in WebGL render

### DIFF
--- a/cocos2d/clipping-nodes/CCClippingNodeWebGLRenderCmd.js
+++ b/cocos2d/clipping-nodes/CCClippingNodeWebGLRenderCmd.js
@@ -32,15 +32,7 @@
         this._afterDrawStencilCmd = new cc.CustomRenderCmd(this, this._onAfterDrawStencil);
         this._afterVisitCmd = new cc.CustomRenderCmd(this, this._onAfterVisit);
 
-        this._currentStencilFunc = null;
-        this._currentStencilRef = null;
-        this._currentStencilValueMask = null;
-        this._currentStencilFail = null;
-        this._currentStencilPassDepthFail = null;
-        this._currentStencilPassDepthPass = null;
-        this._currentStencilWriteMask = null;
         this._currentStencilEnabled = null;
-        this._currentDepthWriteMask = null;
         this._mask_layer_le = null;
     };
 
@@ -142,33 +134,6 @@
             node._stencil._parent = node;
     };
 
-    proto._drawFullScreenQuadClearStencil = function () {
-        // draw a fullscreen solid rectangle to clear the stencil buffer
-        var projStack = cc.projection_matrix_stack;
-        //cc.kmGLMatrixMode(cc.KM_GL_PROJECTION);
-        //cc.kmGLPushMatrix();
-        //cc.kmGLLoadIdentity();
-        projStack.push();
-        projStack.top.identity();
-
-        //cc.kmGLMatrixMode(cc.KM_GL_MODELVIEW);
-        //cc.kmGLPushMatrix();
-        //cc.kmGLLoadIdentity();
-        var modelViewStack = cc.modelview_matrix_stack;
-        modelViewStack.push();
-        modelViewStack.top.identity();
-
-        cc._drawingUtil.drawSolidRect(cc.p(-1, -1), cc.p(1, 1), cc.color(255, 255, 255, 255));
-
-        //cc.kmGLMatrixMode(cc.KM_GL_PROJECTION);
-        //cc.kmGLPopMatrix();
-        projStack.pop();
-
-        //cc.kmGLMatrixMode(cc.KM_GL_MODELVIEW);
-        //cc.kmGLPopMatrix();
-        modelViewStack.pop();
-    };
-
     proto._onBeforeVisit = function(ctx){
         var gl = ctx || cc._renderContext, node = this._node;
         cc.ClippingNode.WebGLRenderCmd._layer++;
@@ -182,28 +147,19 @@
         this._mask_layer_le = mask_layer | mask_layer_l;
         // manually save the stencil state
         this._currentStencilEnabled = gl.isEnabled(gl.STENCIL_TEST);
-        this._currentStencilWriteMask = gl.getParameter(gl.STENCIL_WRITEMASK);
-        this._currentStencilFunc = gl.getParameter(gl.STENCIL_FUNC);
-        this._currentStencilRef = gl.getParameter(gl.STENCIL_REF);
-        this._currentStencilValueMask = gl.getParameter(gl.STENCIL_VALUE_MASK);
-        this._currentStencilFail = gl.getParameter(gl.STENCIL_FAIL);
-        this._currentStencilPassDepthFail = gl.getParameter(gl.STENCIL_PASS_DEPTH_FAIL);
-        this._currentStencilPassDepthPass = gl.getParameter(gl.STENCIL_PASS_DEPTH_PASS);
 
+        gl.clear(gl.DEPTH_BUFFER_BIT);
         // enable stencil use
         gl.enable(gl.STENCIL_TEST);
-        gl.stencilMask(mask_layer);
-        this._currentDepthWriteMask = gl.getParameter(gl.DEPTH_WRITEMASK);
 
         gl.depthMask(false);
 
+        gl.clear(gl.STENCIL_BUFFER_BIT);
         gl.stencilFunc(gl.NEVER, mask_layer, mask_layer);
-        gl.stencilOp(!node.inverted ? gl.ZERO : gl.REPLACE, gl.KEEP, gl.KEEP);
+        gl.stencilOp(gl.REPLACE, gl.KEEP, gl.KEEP);
 
-        this._drawFullScreenQuadClearStencil();
-
-        gl.stencilFunc(gl.NEVER, mask_layer, mask_layer);
-        gl.stencilOp(!node.inverted ? gl.REPLACE : gl.ZERO, gl.KEEP, gl.KEEP);
+        gl.stencilMask(mask_layer);
+        gl.clear(gl.STENCIL_BUFFER_BIT);
 
         if (node.alphaThreshold < 1) {            //TODO desktop
             var program = cc.shaderCache.programForKey(cc.SHADER_POSITION_TEXTURECOLORALPHATEST);
@@ -217,18 +173,14 @@
 
     proto._onAfterDrawStencil = function(ctx){
         var gl = ctx || cc._renderContext;
-        gl.depthMask(this._currentDepthWriteMask);
-
-        gl.stencilFunc(gl.EQUAL, this._mask_layer_le, this._mask_layer_le);
+        gl.depthMask(true);
+        gl.stencilFunc(!this._node.inverted ? gl.EQUAL : gl.NOTEQUAL, this._mask_layer_le, this._mask_layer_le);
         gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
     };
 
     proto._onAfterVisit = function(ctx){
         var gl = ctx || cc._renderContext;
-
-        gl.stencilFunc(this._currentStencilFunc, this._currentStencilRef, this._currentStencilValueMask);
-        gl.stencilOp(this._currentStencilFail, this._currentStencilPassDepthFail, this._currentStencilPassDepthPass);
-        gl.stencilMask(this._currentStencilWriteMask);
+        
         if (!this._currentStencilEnabled)
             gl.disable(gl.STENCIL_TEST);
 

--- a/extensions/ccui/layouts/UILayoutWebGLRenderCmd.js
+++ b/extensions/ccui/layouts/UILayoutWebGLRenderCmd.js
@@ -118,22 +118,7 @@
         var gl = ctx || cc._renderContext;
         gl.disable(gl.SCISSOR_TEST);
     };
-
-    proto._drawFullScreenQuadClearStencil = function(){
-        // draw a fullscreen solid rectangle to clear the stencil buffer
-        cc.kmGLMatrixMode(cc.KM_GL_PROJECTION);
-        cc.kmGLPushMatrix();
-        cc.kmGLLoadIdentity();
-        cc.kmGLMatrixMode(cc.KM_GL_MODELVIEW);
-        cc.kmGLPushMatrix();
-        cc.kmGLLoadIdentity();
-        cc._drawingUtil.drawSolidRect(cc.p(-1,-1), cc.p(1,1), cc.color(255, 255, 255, 255));
-        cc.kmGLMatrixMode(cc.KM_GL_PROJECTION);
-        cc.kmGLPopMatrix();
-        cc.kmGLMatrixMode(cc.KM_GL_MODELVIEW);
-        cc.kmGLPopMatrix();
-    };
-
+    
     proto.rebindStencilRendering = function(stencil){};
 
     proto.transform = function(parentCmd, recursive){

--- a/extensions/ccui/layouts/UILayoutWebGLRenderCmd.js
+++ b/extensions/ccui/layouts/UILayoutWebGLRenderCmd.js
@@ -31,15 +31,6 @@
         this._needDraw = false;
 
         this._currentStencilEnabled = 0;
-        this._currentStencilWriteMask = 0;
-        this._currentStencilFunc = 0;
-        this._currentStencilRef = 0;
-        this._currentStencilValueMask = 0;
-        this._currentStencilFail = 0;
-        this._currentStencilPassDepthFail = 0;
-        this._currentStencilPassDepthPass = 0;
-        this._currentDepthWriteMask = false;
-
         this._mask_layer_le = 0;
 
         this._beforeVisitCmdStencil = new cc.CustomRenderCmd(this, this._onBeforeVisitStencil);
@@ -85,45 +76,31 @@
 
         // manually save the stencil state
         this._currentStencilEnabled = gl.isEnabled(gl.STENCIL_TEST);
-        this._currentStencilWriteMask = gl.getParameter(gl.STENCIL_WRITEMASK);
-        this._currentStencilFunc = gl.getParameter(gl.STENCIL_FUNC);
-        this._currentStencilRef = gl.getParameter(gl.STENCIL_REF);
-        this._currentStencilValueMask = gl.getParameter(gl.STENCIL_VALUE_MASK);
-        this._currentStencilFail = gl.getParameter(gl.STENCIL_FAIL);
-        this._currentStencilPassDepthFail = gl.getParameter(gl.STENCIL_PASS_DEPTH_FAIL);
-        this._currentStencilPassDepthPass = gl.getParameter(gl.STENCIL_PASS_DEPTH_PASS);
+
+        gl.clear(gl.DEPTH_BUFFER_BIT);
 
         gl.enable(gl.STENCIL_TEST);
-
-        gl.stencilMask(mask_layer);
-
-        this._currentDepthWriteMask = gl.getParameter(gl.DEPTH_WRITEMASK);
 
         gl.depthMask(false);
 
         gl.stencilFunc(gl.NEVER, mask_layer, mask_layer);
-        gl.stencilOp(gl.ZERO, gl.KEEP, gl.KEEP);
-
-        // draw a fullscreen solid rectangle to clear the stencil buffer
-        this._drawFullScreenQuadClearStencil();
-
-        gl.stencilFunc(gl.NEVER, mask_layer, mask_layer);
         gl.stencilOp(gl.REPLACE, gl.KEEP, gl.KEEP);
+
+        gl.stencilMask(mask_layer);
+        gl.clear(gl.STENCIL_BUFFER_BIT);
+
     };
 
     proto._onAfterDrawStencil = function(ctx){
         var gl = ctx || cc._renderContext;
-        gl.depthMask(this._currentDepthWriteMask);
+        gl.depthMask(true);
         gl.stencilFunc(gl.EQUAL, this._mask_layer_le, this._mask_layer_le);
         gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
     };
 
     proto._onAfterVisitStencil = function(ctx){
         var gl = ctx || cc._renderContext;
-        // manually restore the stencil state
-        gl.stencilFunc(this._currentStencilFunc, this._currentStencilRef, this._currentStencilValueMask);
-        gl.stencilOp(this._currentStencilFail, this._currentStencilPassDepthFail, this._currentStencilPassDepthPass);
-        gl.stencilMask(this._currentStencilWriteMask);
+
         if (!this._currentStencilEnabled)
             gl.disable(gl.STENCIL_TEST);
         ccui.Layout.WebGLRenderCmd._layer--;


### PR DESCRIPTION
- remove calling of very heavy function gl.GetParameter
- clear depth & stencil buffer by gl.clear
- use stencilOp gl.REPLACE on before draw stencil

This patch improves performance of stencil clipping in web GL Render. It passes all clipping tests.

Here performance compare in scene with ccui.ScrollView and 5 ccui.Layouts with clipping enabled in it(In Google Chrome browser, Core i7 Processor, GeForce 750M graphics):

- Before(first Task Manager of Chrome for game tab, second CPU profiler):

![2016-03-31 12 08 13](https://cloud.githubusercontent.com/assets/10628482/14171027/d1f4c846-f741-11e5-89eb-b3eb7792ba11.png)
![2016-03-31 12 08 58](https://cloud.githubusercontent.com/assets/10628482/14171026/d1cc302a-f741-11e5-9308-ea0e0825603f.png)

- After(first Task Manager of Chrome for game tab, second CPU profiler):

![2016-03-31 12 13 13](https://cloud.githubusercontent.com/assets/10628482/14171138/7255c0ce-f742-11e5-8385-c0432bdc6242.png)
![2016-03-31 12 13 43](https://cloud.githubusercontent.com/assets/10628482/14171137/7232e108-f742-11e5-819e-3dbb938ee71b.png)



