### PR TITLE
Fix nested clipping node

### DIFF
--- a/cocos2d/clipping-nodes/CCClippingNodeWebGLRenderCmd.js
+++ b/cocos2d/clipping-nodes/CCClippingNodeWebGLRenderCmd.js
@@ -180,11 +180,21 @@
 
     proto._onAfterVisit = function(ctx){
         var gl = ctx || cc._renderContext;
-        
-        if (!this._currentStencilEnabled)
+
+        cc.ClippingNode.WebGLRenderCmd._layer--;
+
+        if (this._currentStencilEnabled)
+        {
+            var mask_layer = 0x1 << ccui.Layout.WebGLRenderCmd._layer;
+            var mask_layer_l = mask_layer - 1;
+            var mask_layer_le = mask_layer | mask_layer_l;
+
+            gl.stencilFunc(gl.EQUAL, mask_layer_le, mask_layer_le);
+        }
+        else
+        {
             gl.disable(gl.STENCIL_TEST);
 
-        // we are done using this layer, decrement
-        cc.ClippingNode.WebGLRenderCmd._layer--;
-    }
+        }
+    };
 })();

--- a/cocos2d/clipping-nodes/CCClippingNodeWebGLRenderCmd.js
+++ b/cocos2d/clipping-nodes/CCClippingNodeWebGLRenderCmd.js
@@ -189,6 +189,7 @@
             var mask_layer_l = mask_layer - 1;
             var mask_layer_le = mask_layer | mask_layer_l;
 
+            gl.stencilMask(mask_layer);
             gl.stencilFunc(gl.EQUAL, mask_layer_le, mask_layer_le);
         }
         else

--- a/extensions/ccui/layouts/UILayoutWebGLRenderCmd.js
+++ b/extensions/ccui/layouts/UILayoutWebGLRenderCmd.js
@@ -109,6 +109,7 @@
             var mask_layer_l = mask_layer - 1;
             var mask_layer_le = mask_layer | mask_layer_l;
 
+            gl.stencilMask(mask_layer);
             gl.stencilFunc(gl.EQUAL, mask_layer_le, mask_layer_le);
         }
         else

--- a/extensions/ccui/layouts/UILayoutWebGLRenderCmd.js
+++ b/extensions/ccui/layouts/UILayoutWebGLRenderCmd.js
@@ -101,9 +101,20 @@
     proto._onAfterVisitStencil = function(ctx){
         var gl = ctx || cc._renderContext;
 
-        if (!this._currentStencilEnabled)
-            gl.disable(gl.STENCIL_TEST);
         ccui.Layout.WebGLRenderCmd._layer--;
+
+        if (this._currentStencilEnabled)
+        {
+            var mask_layer = 0x1 << ccui.Layout.WebGLRenderCmd._layer;
+            var mask_layer_l = mask_layer - 1;
+            var mask_layer_le = mask_layer | mask_layer_l;
+
+            gl.stencilFunc(gl.EQUAL, mask_layer_le, mask_layer_le);
+        }
+        else
+        {
+            gl.disable(gl.STENCIL_TEST);
+        }
     };
 
     proto._onBeforeVisitScissor = function(ctx){


### PR DESCRIPTION
This PR adds restoring state of `stencilFunc` and `stencilMask` on afterDrawing of clipping node content.