### PR TITLE
Fix visibility of nodes in ccui.ScrollView

### DIFF
--- a/extensions/ccui/uiwidgets/scroll-widget/UIScrollViewCanvasRenderCmd.js
+++ b/extensions/ccui/uiwidgets/scroll-widget/UIScrollViewCanvasRenderCmd.js
@@ -32,7 +32,9 @@
             scaleY = cc.view.getScaleY();
         var context = ctx || cc._renderContext;
         context.computeRealOffsetY();
-        
+
+        this._node.updateChildren();
+
         for (i = 0, len = locCmds.length; i < len; i++) {
             var checkNode = locCmds[i]._node;
             if(checkNode instanceof ccui.ScrollView)

--- a/extensions/ccui/uiwidgets/scroll-widget/UIScrollViewWebGLRenderCmd.js
+++ b/extensions/ccui/uiwidgets/scroll-widget/UIScrollViewWebGLRenderCmd.js
@@ -36,6 +36,9 @@
         if (!locCmds) {
             return;
         }
+
+        this._node.updateChildren();
+
         for (i = 0, len = locCmds.length; i < len; i++) {
             checkNode = locCmds[i]._node;
             if(checkNode instanceof ccui.ScrollView)


### PR DESCRIPTION
`_inViewRect` of inner nodes should be updated before checking in `rendering` function of ScrollView.