### PR TITLE
problem with canvas2d

### DIFF
--- a/cocos2d/core/sprites/CCSpriteCanvasRenderCmd.js
+++ b/cocos2d/core/sprites/CCSpriteCanvasRenderCmd.js
@@ -201,8 +201,10 @@
         textureLoaded = textureLoaded || pNewTexture._textureLoaded;
         if (textureLoaded) {
             var curColor = this._node.getColor();
-            if (curColor.r !== 255 || curColor.g !== 255 || curColor.b !== 255)
+            if (curColor.r !== 255 || curColor.g !== 255 || curColor.b !== 255||
+                this._displayedColor.r !== 255 || this._displayedColor.g !== 255 || this._displayedColor.b !== 255) {
                 this._updateColor();
+            }
         }
     };
 


### PR DESCRIPTION
Problem with canvas2d, when FileNode have other inner fileNode and inner fileNode have loop animation and main fileNode have animation change color. If play animation which change color without loop, inner FileNode have problem with no rotated image in atlas only in Canvas2d in webGL works normal (example with cocos2d-html5 v.11:http://mab.to/eo7YoVAs9) 