### PR TITLE
Fix for rendering issues for nested clipping nodes in WebGL rendering codepath.

### DIFF
--- a/cocos2d/clipping-nodes/CCClippingNodeWebGLRenderCmd.js
+++ b/cocos2d/clipping-nodes/CCClippingNodeWebGLRenderCmd.js
@@ -185,7 +185,7 @@
 
         if (this._currentStencilEnabled)
         {
-            var mask_layer = 0x1 << cc.ClippingNode.WebGLRenderCmd._layer--;
+            var mask_layer = 0x1 << cc.ClippingNode.WebGLRenderCmd._layer;
             var mask_layer_l = mask_layer - 1;
             var mask_layer_le = mask_layer | mask_layer_l;
 

--- a/cocos2d/clipping-nodes/CCClippingNodeWebGLRenderCmd.js
+++ b/cocos2d/clipping-nodes/CCClippingNodeWebGLRenderCmd.js
@@ -155,7 +155,6 @@
 
         gl.depthMask(false);
 
-        gl.clear(gl.STENCIL_BUFFER_BIT);
         gl.stencilFunc(gl.NEVER, mask_layer, mask_layer);
         gl.stencilOp(gl.REPLACE, gl.KEEP, gl.KEEP);
 
@@ -186,7 +185,7 @@
 
         if (this._currentStencilEnabled)
         {
-            var mask_layer = 0x1 << ccui.Layout.WebGLRenderCmd._layer;
+            var mask_layer = 0x1 << cc.ClippingNode.WebGLRenderCmd._layer--;
             var mask_layer_l = mask_layer - 1;
             var mask_layer_le = mask_layer | mask_layer_l;
 


### PR DESCRIPTION
WebGL clipping nodes are clearing the stencil buffer twice, and one of those is clearing without regard for the currently bound value of the stencil mask. This will cause issues in nested clipping nodes, as it will clear the value in the bitfield for the previous level. This behavior is inconsistent with native platforms and previous versions of cocos2d-x. 

In addition to this, when restoring the stencil buffer state post visit, we use a seemingly unrelated variable to set our bit mask, instead of the clipping node's layer counter. 