### PR TITLE
Fix label rect before calculating transform.

### DIFF
--- a/cocos2d/core/labelttf/CCLabelTTFCanvasRenderCmd.js
+++ b/cocos2d/core/labelttf/CCLabelTTFCanvasRenderCmd.js
@@ -312,10 +312,10 @@ cc.LabelTTF._firsrEnglish = /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôû]/;
     proto.updateStatus = function () {
         var flags = cc.Node._dirtyFlags, locFlag = this._dirtyFlag;
 
-        cc.Node.RenderCmd.prototype.updateStatus.call(this);
-
         if (locFlag & flags.textDirty)
             this._updateTexture();
+
+        cc.Node.RenderCmd.prototype.updateStatus.call(this);
 
         if (this._dirtyFlag & flags.transformDirty){
             this.transform(this.getParentRenderCmd(), true);
@@ -326,10 +326,10 @@ cc.LabelTTF._firsrEnglish = /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôû]/;
     proto._syncStatus = function (parentCmd) {
         var flags = cc.Node._dirtyFlags, locFlag = this._dirtyFlag;
 
-        cc.Node.RenderCmd.prototype._syncStatus.call(this, parentCmd);
-
         if (locFlag & flags.textDirty)
             this._updateTexture();
+
+        cc.Node.RenderCmd.prototype._syncStatus.call(this, parentCmd);
 
         if (cc._renderType === cc.game.RENDER_TYPE_WEBGL || locFlag & flags.transformDirty)
             this.transform(parentCmd);


### PR DESCRIPTION
Fixes https://github.com/cocos2d/cocos2d-html5/issues/3279.

After debugging label reader process, I've found that in `SpriteWebGLRenderCmd.transform` function uses an incorrect rect of label(not recalculated after label's string changes). It's called from Node's render cmd `updateStatus` function.

Labels' render cmd overrides it, but calculates correct rect in `_updateTexture` function AFTER transform, so there was a previous rect size on screen and labels distorts like in my issue above(a good example is: create a ccui.TextFiled(or cc.TextFieldTTF) with long placeholder text and type one symbol: letter will have width like placeholder text).