### PR TITLE
Fix issue with scrolling the page

### DIFF
--- a/cocos2d/core/platform/CCInputManager.js
+++ b/cocos2d/core/platform/CCInputManager.js
@@ -491,8 +491,8 @@ cc.inputManager = /** @lends cc.inputManager# */{
                 mouseEvent.setScrollData(0, event.wheelDelta);
                 cc.eventManager.dispatchEvent(mouseEvent);
 
-                event.stopPropagation();
-                event.preventDefault();
+                //event.stopPropagation();
+                //event.preventDefault();
             }, false);
 
             /* firefox fix */
@@ -505,8 +505,8 @@ cc.inputManager = /** @lends cc.inputManager# */{
                 mouseEvent.setScrollData(0, event.detail * -120);
                 cc.eventManager.dispatchEvent(mouseEvent);
 
-                event.stopPropagation();
-                event.preventDefault();
+                //event.stopPropagation();
+                //event.preventDefault();
             }, false);
         }
 


### PR DESCRIPTION
When the page contains cocos2d-html5 canvas and you put the mouse pointer over it, the scroll wheel does not work. For games which are used inside Facebook Canvas the scroll feature should work.

This fix disables the preventing of default scrolling when the mouse wheel is used.