### PR TITLE
Add correct line breaks support for non-latin languages

### DIFF
--- a/cocos2d/core/labelttf/CCLabelTTFCanvasRenderCmd.js
+++ b/cocos2d/core/labelttf/CCLabelTTFCanvasRenderCmd.js
@@ -26,11 +26,11 @@ cc.LabelTTF.wrapInspection = true;
 
 //Support: English French German
 //Other as Oriental Language
-cc.LabelTTF._wordRex = /([a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôû]+|\S)/;
+cc.LabelTTF._wordRex = /(\S+)/;
 cc.LabelTTF._symbolRex = /^[!,.:;}\]%\?>、‘“》？。，！]/;
-cc.LabelTTF._lastWordRex = /([a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôû]+|\S)$/;
-cc.LabelTTF._lastEnglish = /[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôû]+$/;
-cc.LabelTTF._firsrEnglish = /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôû]/;
+cc.LabelTTF._lastWordRex = /(\S+)$/;
+cc.LabelTTF._lastEnglish = /\S+$/;
+cc.LabelTTF._firsrEnglish = /^\S/;
 
 (function() {
     cc.LabelTTF.RenderCmd = function () {


### PR DESCRIPTION
Without this patch, the Cyrillic and other non-latin languages had an issue with line breaks in LabelTTF. The world was broken in any place.

Before in LabelTTF the string "Привіт як в тебе справи" will be shown next way:
```
Привіт як в те
бе справи
```

The word ```тебе``` was cut into pieces
After the patch it works ok:
```
Привіт як в 
тебе справи
```