### PR TITLE
Fix Ajax NS_ERROR_FAILURE in Firefox

### DIFF
--- a/CCBoot.js
+++ b/CCBoot.js
@@ -791,17 +791,23 @@ cc.loader = (function () {
                     // IE-specific logic here
                     xhr.setRequestHeader("Accept-Charset", "utf-8");
                     xhr.onreadystatechange = function () {
+                        var status = 0;
+                        try {status = xhr.status} catch(err){}
                         if(xhr.readyState === 4)
-                            xhr.status === 200 ? cb(null, xhr.responseText) : cb({status:xhr.status, errorMessage:errInfo}, null);
+                            status === 200 ? cb(null, xhr.responseText) : cb({status:status, errorMessage:errInfo}, null);
                     };
                 } else {
                     if (xhr.overrideMimeType) xhr.overrideMimeType("text\/plain; charset=utf-8");
                     xhr.onload = function () {
+                        var status = 0;
+                        try {status = xhr.status} catch(err){}
                         if(xhr.readyState === 4)
-                            xhr.status === 200 ? cb(null, xhr.responseText) : cb({status:xhr.status, errorMessage:errInfo}, null);
+                            status === 200 ? cb(null, xhr.responseText) : cb({status:status, errorMessage:errInfo}, null);
                     };
                     xhr.onerror = function(){
-                        cb({status:xhr.status, errorMessage:errInfo}, null);
+                        var status = 0;
+                        try {status = xhr.status} catch(err){}
+                        cb({status:status, errorMessage:errInfo}, null);
                     };
                 }
                 xhr.send(null);
@@ -823,7 +829,10 @@ cc.loader = (function () {
                     if (xhr.overrideMimeType) xhr.overrideMimeType("text\/plain; charset=utf-8");
                 }
                 xhr.send(null);
-                if (!xhr.readyState === 4 || xhr.status !== 200) {
+                var status = 0;
+                try {status = xhr.status} catch(err){}
+
+                if (!xhr.readyState === 4 || status !== 200) {
                     return null;
                 }
                 return xhr.responseText;
@@ -844,11 +853,15 @@ cc.loader = (function () {
                 if (arrayBuffer) {
                     window.msg = arrayBuffer;
                 }
+                var status = 0;
+                try {status = xhr.status} catch(err){}
                 if(xhr.readyState === 4)
-                    xhr.status === 200 ? cb(null, xhr.response) : cb({status:xhr.status, errorMessage:errInfo}, null);
+                    status === 200 ? cb(null, xhr.response) : cb({status:status, errorMessage:errInfo}, null);
             };
             xhr.onerror = function(){
-                cb({status:xhr.status, errorMessage:errInfo}, null);
+                var status = 0;
+                try {status = xhr.status} catch(err){}
+                cb({status:status, errorMessage:errInfo}, null);
             };
             xhr.send(null);
         },

--- a/cocos2d/core/utils/BinaryLoader.js
+++ b/cocos2d/core/utils/BinaryLoader.js
@@ -41,7 +41,9 @@ cc.loader.loadBinary = function (url, cb) {
         // IE-specific logic here
         xhr.setRequestHeader("Accept-Charset", "x-user-defined");
         xhr.onreadystatechange = function () {
-            if (xhr.readyState === 4 && xhr.status === 200) {
+            var status = 0;
+            try {status = xhr.status} catch(err){}
+            if (xhr.readyState === 4 && status === 200) {
                 var fileContents = cc._convertResponseBodyToText(xhr["responseBody"]);
                 cb(null, self._str2Uint8Array(fileContents));
             } else cb(errInfo);
@@ -49,7 +51,9 @@ cc.loader.loadBinary = function (url, cb) {
     } else {
         if (xhr.overrideMimeType) xhr.overrideMimeType("text\/plain; charset=x-user-defined");
         xhr.onload = function () {
-            xhr.readyState === 4 && xhr.status === 200 ? cb(null, self._str2Uint8Array(xhr.responseText)) : cb(errInfo);
+            var status = 0;
+            try {status = xhr.status} catch(err){}
+            xhr.readyState === 4 && status === 200 ? cb(null, self._str2Uint8Array(xhr.responseText)) : cb(errInfo);
         };
     }
     xhr.send(null);
@@ -83,7 +87,9 @@ cc.loader.loadBinarySync = function (url) {
     if (cc.loader.loadBinary._IEFilter) {
         req.setRequestHeader("Accept-Charset", "x-user-defined");
         req.send(null);
-        if (req.status !== 200) {
+        var status = 0;
+        try {status = req.status} catch(err){}
+        if (status !== 200) {
             cc.log(errInfo);
             return null;
         }
@@ -96,7 +102,9 @@ cc.loader.loadBinarySync = function (url) {
         if (req.overrideMimeType)
             req.overrideMimeType('text\/plain; charset=x-user-defined');
         req.send(null);
-        if (req.status !== 200) {
+        var status = 0;
+        try {status = req.status} catch(err){}
+        if (status !== 200) {
             cc.log(errInfo);
             return null;
         }

--- a/extensions/ccb-reader/CCBReader.js
+++ b/extensions/ccb-reader/CCBReader.js
@@ -222,7 +222,9 @@ cc.BuilderReader = cc.Class.extend({
         if (/msie/i.test(navigator.userAgent) && !/opera/i.test(navigator.userAgent)) {
             req.setRequestHeader("Accept-Charset", "x-user-defined");
             req.send(null);
-            if (req.status !== 200) {
+            var status = 0;
+            try {status = req.status} catch(err){}
+            if (status !== 200) {
                 cc.log(errInfo);
                 return null;
             }
@@ -236,7 +238,9 @@ cc.BuilderReader = cc.Class.extend({
             if (req.overrideMimeType)
                 req.overrideMimeType('text\/plain; charset=x-user-defined');
             req.send(null);
-            if (req.status !== 200) {
+            var status = 0;
+            try {status = req.status} catch(err){}
+            if (status !== 200) {
                 cc.log(errInfo);
                 return null;
             }


### PR DESCRIPTION
Firefox will fire NS_ERROR_FAILUER exception if we access xhr.status field in some situation.  More: http://helpful.knobs-dials.com/index.php/0x80004005_(NS_ERROR_FAILURE)_and_other_firefox_errors

This fix adds try catch to catch possible errors in Firefox.