### PR TITLE
Fix black border in LabelTTF in WebGL mode

### DIFF
--- a/cocos2d/core/labelttf/CCLabelTTFCanvasRenderCmd.js
+++ b/cocos2d/core/labelttf/CCLabelTTFCanvasRenderCmd.js
@@ -408,7 +408,10 @@ cc.LabelTTF._firsrEnglish = /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôû]/;
         if (node._string.length === 0) {
             locLabelCanvas.width = width;
             locLabelCanvas.height = height;
-            node._texture && node._texture.handleLoadedTexture();
+            node._texture && node._texture.handleLoadedTexture(true);
+            if(this._updateBlendFunc) {
+                this._updateBlendFunc();
+            }
             node.setTextureRect(this._texRect);
             return true;
         }


### PR DESCRIPTION
The labels created via LabelTTF in WebGL mode has a black border. It is visible if you place a white label over white background. The reason is that the texture is rendered with premultiplied alpha, but the sprite created from this textures thinks that alpha is not premultiplied. This fix sets the premultiplied alpha mode for textures inside LabelTTF.