### PR TITLE
Catch textures errors

### DIFF
--- a/cocos2d/core/textures/CCTexture2D.js
+++ b/cocos2d/core/textures/CCTexture2D.js
@@ -187,6 +187,7 @@ cc.game.addEventListener(cc.game.EVENT_RENDERER_INITED, function () {
              * handle loaded texture
              */
             handleLoadedTexture: function () {
+            try {
                 var self = this;
                 if (self._textureLoaded) return;
                 if (!self._htmlElementObj) {
@@ -201,6 +202,7 @@ cc.game.addEventListener(cc.game.EVENT_RENDERER_INITED, function () {
 
                 //dispatch load event to listener.
                 self.dispatchEvent("load");
+            } catch(err) { console.warn("Texture load error", err); }
             },
 
             /**

--- a/cocos2d/core/textures/TexturesWebGL.js
+++ b/cocos2d/core/textures/TexturesWebGL.js
@@ -418,11 +418,13 @@ cc._tmp.WebGLTexture2D = function () {
          * @param {HTMLImageElement|HTMLCanvasElement} element
          */
         initWithElement: function (element) {
+            try {
             if (!element)
                 return;
             this._webTextureObj = cc._renderContext.createTexture();
             this._htmlElementObj = element;
             this._textureLoaded = true;
+            } catch (err) {console.warn(err);}
             // Textures should be loaded with premultiplied alpha in order to avoid gray bleeding
             // when semitransparent textures are interpolated (e.g. when scaled).
             this._hasPremultipliedAlpha = true;
@@ -856,6 +858,7 @@ cc._tmp.WebGLTextureCache = function () {
     var _p = cc.textureCache;
 
     _p.handleLoadedTexture = function (url) {
+        try {
         var locTexs = this._textures, tex, ext;
         //remove judge(webgl)
         if (!cc.game._rendererInitialized) {
@@ -873,6 +876,7 @@ cc._tmp.WebGLTextureCache = function () {
         else {
             tex.handleLoadedTexture();
         }
+        } catch (err) {console.warn(err);}
     };
 
     /**


### PR DESCRIPTION
In some cases, textures2d can fire exceptions, which stops whole cocos from working. We have collected a bunch of errors from Sentry and added try/catch in places where the errors have occurred in real players.