### PR TITLE
Catch LabelTTF errors

### DIFF
--- a/cocos2d/core/labelttf/CCLabelTTF.js
+++ b/cocos2d/core/labelttf/CCLabelTTF.js
@@ -923,6 +923,7 @@ document.body ?
  * @private
  */
 cc.LabelTTF.__getFontHeightByDiv = function (fontName, fontSize) {
+    try{
     var clientHeight, labelDiv = cc.LabelTTF.__labelHeightDiv;
     if(fontName instanceof cc.FontDefinition){
         /** @type cc.FontDefinition */
@@ -951,6 +952,8 @@ cc.LabelTTF.__getFontHeightByDiv = function (fontName, fontSize) {
         labelDiv.innerHTML = "";
     }
     return clientHeight;
+    } catch (err) {console.warn(err);}
+    return 10;
 
 };
 

--- a/cocos2d/core/labelttf/CCLabelTTFCanvasRenderCmd.js
+++ b/cocos2d/core/labelttf/CCLabelTTFCanvasRenderCmd.js
@@ -54,6 +54,7 @@ cc.LabelTTF._firsrEnglish = /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôû]/;
     proto.constructor = cc.LabelTTF.RenderCmd;
 
     proto._setFontStyle = function (fontNameOrFontDef, fontSize, fontStyle, fontWeight) {
+        try{
         if(fontNameOrFontDef instanceof cc.FontDefinition){
             this._fontStyleStr = fontNameOrFontDef._getCanvasFontStr();
             this._fontClientHeight = cc.LabelTTF.__getFontHeightByDiv(fontNameOrFontDef);
@@ -62,6 +63,7 @@ cc.LabelTTF._firsrEnglish = /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôû]/;
             this._fontStyleStr = fontStyle + " " + fontWeight + " " + deviceFontSize + "px '" + fontNameOrFontDef + "'";
             this._fontClientHeight = cc.LabelTTF.__getFontHeightByDiv(fontNameOrFontDef, fontSize);
         }
+        } catch (err) {console.warn(err);}
     };
 
     proto._getFontStyle = function () {
@@ -227,6 +229,7 @@ cc.LabelTTF._firsrEnglish = /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôû]/;
     };
 
     proto._drawTTFInCanvas = function (context) {
+        try {
         if (!context)
             return;
         var locStatus = this._status.pop();
@@ -234,6 +237,7 @@ cc.LabelTTF._firsrEnglish = /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôû]/;
         var xOffset = locStatus.xOffset;
         var yOffsetArray = locStatus.OffsetYArray;
         this.drawLabels(context, xOffset, yOffsetArray);
+        } catch (err) {console.warn(err);}
     };
 
     proto._checkWarp = function (strArr, i, maxWidth) {
@@ -392,6 +396,7 @@ cc.LabelTTF._firsrEnglish = /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôû]/;
     proto.constructor = cc.LabelTTF.CacheRenderCmd;
 
     proto._updateTexture = function () {
+        try {
         this._dirtyFlag = this._dirtyFlag & cc.Node._dirtyFlags.textDirty ^ this._dirtyFlag;
         var node = this._node;
         this._updateTTF();
@@ -424,15 +429,21 @@ cc.LabelTTF._firsrEnglish = /^[a-zA-Z0-9ÄÖÜäöüßéèçàùêâîôû]/;
         this._drawTTFInCanvas(locContext);
         node._texture && node._texture.handleLoadedTexture();
         node.setTextureRect(this._texRect);
+        
+        } catch(err) {console.warn("Update texture failed", err)}
         return true;
     };
 
     proto._measureConfig = function () {
+        try {
         this._labelContext.font = this._fontStyleStr;
+        } catch (err) {console.warn(err);}
     };
 
     proto._measure = function (text) {
+        try {
         return this._labelContext.measureText(text).width;
+        } catch (err) {console.warn(err);}
     };
 
 })();


### PR DESCRIPTION
In some cases, LabelTTF can fire exceptions, which stops whole cocos from working. We have collected a bunch of errors from Sentry and added try/catch in places where the errors have occurred in real players.