### PR TITLE
getSlidBallRenderer methods to allow more customization of UISlider

### DIFF
--- a/extensions/ccui/uiwidgets/UISlider.js
+++ b/extensions/ccui/uiwidgets/UISlider.js
@@ -680,6 +680,22 @@ ccui.Slider = ccui.Widget.extend(/** @lends ccui.Slider# */{
         return this._zoomScale;
     },
 
+    getSlidBallNormalRenderer : function () {
+        return this._slidBallNormalRenderer;
+    },
+
+    getSlidBallPressedRenderer : function () {
+        return this._slidBallPressedRenderer;
+    },
+
+    getSlidBallDisabledRenderer : function () {
+        return this._slidBallDisabledRenderer;
+    },
+
+    getSlidBallRenderer : function () {
+        return this._slidBallRenderer;
+    },
+
     /**
      * Returns the "class name" of ccui.LoadingBar.
      * @returns {string}


### PR DESCRIPTION
getSlidBallRenderer methods to allow more customization of UISlider look and feel.

Sprite* getSlidBallNormalRenderer();
Sprite* getSlidBallPressedRenderer();
Sprite* getSlidBallDisabledRenderer();
Node* getSlidBallRenderer();

These functions are needed to maintain html5 API compatibility with JSB API changes made in this pull request:
  https://github.com/cocos2d/cocos2d-x/pull/16532
