### PR TITLE
Fix blurriness dependent on position (#3387)

### DIFF
--- a/cocos2d/core/CCDirectorWebGL.js
+++ b/cocos2d/core/CCDirectorWebGL.js
@@ -215,7 +215,7 @@ cc.game.addEventListener(cc.game.EVENT_RENDERER_INITED, function () {
     };
 
     _p.getZEye = function () {
-        return (this._winSizeInPoints.height / 1.1566 );
+        return (this._winSizeInPoints.height / 1.15469993750);
     };
 
     _p.setViewport = function () {


### PR DESCRIPTION
The camera distance (`ZEye`) is far enough so that the view fits in the frustum, but its value is not precise enough. In consequence the projected image is very slightly zoomed in... enough to cause the artifacts shown in the issue.

After a series of experiments I've found a more precise value for this constant. With the new constant sprites positioned precisely are displayed accurately.

Unfortunately this is not the end of the blurry text issue. Now the blur is not dependent on position, but still present for some reason.