### PR TITLE
WebGL spine defaults to different blend func than native

### DIFF
--- a/extensions/spine/CCSkeletonWebGLRenderCmd.js
+++ b/extensions/spine/CCSkeletonWebGLRenderCmd.js
@@ -103,7 +103,7 @@
                     cc.glBlendFunc(cc.ONE, cc.ONE_MINUS_SRC_COLOR);
                     break;
                 default:
-                    cc.glBlendFunc(locBlendFunc.src, locBlendFunc.dst);
+                    cc.glBlendFunc(premultiAlpha ? cc.ONE : cc.SRC_ALPHA, cc.ONE_MINUS_SRC_ALPHA);
                 }
             } else if (regionTextureAtlas != textureAtlas && textureAtlas) {
                 textureAtlas.drawQuads();


### PR DESCRIPTION
Native spine skeleton renderer will default to blend func GL_ONE/GL_ONE_MINUS_SRC_ALPHA or GL_SRC_ALPHA/GL_ONE_MINUS_SRC_ALPHA, if none are provided. This differs from web, which would just use the nodes blend func. This commit brings web into parity with native.

The issue is described in detail here: https://github.com/cocos2d/cocos2d-x/issues/16786

My fix for now is to bring web into parity with native, by making web behave the same as native. If we would rather do the opposite, I will close this PR and submit one to spine. 