### PR TITLE
Solve the error logic in spine runtime.

### DIFF
--- a/extensions/spine/CCSkeleton.js
+++ b/extensions/spine/CCSkeleton.js
@@ -194,10 +194,7 @@ sp.Skeleton = cc.Node.extend(/** @lends sp.Skeleton# */{
             skeletonJsonReader.scale = scale;
 
             var skeletonJson = cc.loader.getRes(argSkeletonFile);
-            // TODO: FIXME: This operation added for avoid the bug of spine runtime:
-            // https://github.com/EsotericSoftware/spine-runtimes/pull/838
-            var clonedJsonObj = JSON.parse(JSON.stringify(skeletonJson));
-            skeletonData = skeletonJsonReader.readSkeletonData(clonedJsonObj);
+            skeletonData = skeletonJsonReader.readSkeletonData(skeletonJson);
             atlas.dispose(skeletonJsonReader);
             ownsSkeletonData = true;
         } else {

--- a/extensions/spine/Spine.js
+++ b/extensions/spine/Spine.js
@@ -4237,12 +4237,13 @@ var spine;
 			var scale = this.scale;
 			attachment.worldVerticesLength = verticesLength;
 			var vertices = map.vertices;
+			var scaledVertices = spine.Utils.toFloatArray(vertices);
 			if (verticesLength == vertices.length) {
 				if (scale != 1) {
 					for (var i = 0, n = vertices.length; i < n; i++)
-						vertices[i] *= scale;
+						scaledVertices[i] *= scale;
 				}
-				attachment.vertices = spine.Utils.toFloatArray(vertices);
+				attachment.vertices = scaledVertices;
 				return;
 			}
 			var weights = new Array();


### PR DESCRIPTION
@pandamicro 之前 spine runtime 中那个 bug 解决方法有问题，才导致误以为没法解决。今天 spine 官方解决了这个问题，然后我同步过来了。不再需要 clone json object 了。