### PR TITLE
Enable FIX_ARTIFACTS_BY_STRECHING_TEXEL by default

### DIFF
--- a/cocos2d/core/platform/CCConfig.js
+++ b/cocos2d/core/platform/CCConfig.js
@@ -56,7 +56,7 @@ window["CocosEngine"] = cc.ENGINE_VERSION = "Cocos2d-JS v3.14";
  * @constant
  * @type {Number}
  */
-cc.FIX_ARTIFACTS_BY_STRECHING_TEXEL = 0;
+cc.FIX_ARTIFACTS_BY_STRECHING_TEXEL = 1;
 
 /**
  * Position of the FPS (Default: 0,0 (bottom-left corner))<br/>


### PR DESCRIPTION
It seems it was disabled accidentally in one of the latest commits.