### PR TITLE
cc.hexToColor creating cc.Color with alpha = 0

### DIFF
--- a/cocos2d/core/platform/CCTypes.js
+++ b/cocos2d/core/platform/CCTypes.js
@@ -794,7 +794,7 @@ cc.hexToColor = function (hex) {
     var r = c >> 16;
     var g = (c >> 8) % 256;
     var b = c % 256;
-    return new cc.Color(r, g, b);
+    return cc.color(r, g, b);
 };
 
 /**


### PR DESCRIPTION
When creating a cc.Color passing the hex code (e.g. new cc.Color("#ff06ff"); ), it creates a cc.Color with 0 alpha.
I think it would be best to create it with full alpha (a = 255)