### PR TITLE
set default value for alpha

### DIFF
--- a/cocos2d/core/platform/CCTypes.js
+++ b/cocos2d/core/platform/CCTypes.js
@@ -37,7 +37,7 @@ cc.Color = function (r, g, b, a) {
     r = r || 0;
     g = g || 0;
     b = b || 0;
-    a = a || 0;
+    a = (a == null) ? 255 : a;
     this._val = ((r << 24) >>> 0) + (g << 16) + (b << 8) + a;
 };
 


### PR DESCRIPTION
cc.Color - set the default value for alpha to 255, if undefined or null.
Reason: when porting an existing project from cocos2d-x 3.13.1 to 3.14.1, all nodes are drawn with transparent colors, as the default value of alpha was set to 255 for the 3.13.1 and 0 for 3.14.1.