### PR TITLE
Fix reschedule issue with same callback

### DIFF
--- a/cocos2d/core/CCScheduler.js
+++ b/cocos2d/core/CCScheduler.js
@@ -222,22 +222,20 @@ cc.inject({
             } else {//advanced usage
                 if (this._useDelay) {
                     if (this._elapsed >= this._delay) {
+                        this._timesExecuted += 1;  // important to increment before call trigger
                         this.trigger();
-
                         this._elapsed -= this._delay;
-                        this._timesExecuted += 1;
                         this._useDelay = false;
                     }
                 } else {
                     if (this._elapsed >= this._interval) {
+                        this._timesExecuted += 1;  // important to increment before call trigger
                         this.trigger();
-
                         this._elapsed = 0;
-                        this._timesExecuted += 1;
                     }
                 }
 
-                if (this._callback && !this._runForever && this._timesExecuted > this._repeat)
+                if (this._callback && this.isExhausted())
                     this.cancel();
             }
         }
@@ -260,6 +258,10 @@ cc.inject({
     cancel: function () {
         //override
         this._scheduler.unschedule(this._callback, this._target);
+    },
+
+    isExhausted: function () {
+        return !this._runForever && this._timesExecuted > this._repeat;
     }
 }, CallbackTimer.prototype);
 
@@ -609,7 +611,7 @@ cc.Scheduler = cc.Class.extend(/** @lends cc.Scheduler# */{
         } else {
             for (i = 0; i < element.timers.length; i++) {
                 timer = element.timers[i];
-                if (callback === timer._callback) {
+                if (!timer.isExhausted() && callback === timer._callback) {
                     cc.log(cc._LogInfos.Scheduler_scheduleCallbackForTarget, timer.getInterval().toFixed(4), interval.toFixed(4));
                     timer._interval = interval;
                     return;


### PR DESCRIPTION
**The issue:**
* create timer with some repeat count
  cc.director.getScheduler().schedule(callback, target, interval, repeat, delay, paused, key);
* wait for last repeat executed
* in timer callback reschedule it again with the same callback
* as result timer is broken and will never be executed

**Reason:**
When we reschedule timer again from callback the scheduler just updates interval value:
`timer._interval = interval;`

After callback executed timer will be canceled:
```
if (this._callback && !this._runForever && this._timesExecuted > this._repeat)
     this.cancel();
```

**Fix:**
Scheduler will update interval only for not exhausted timers (still running).
In our case, it will create new internal timer object and old one will be canceled after callback.