### PR TITLE
Fix bug viewport bug in RenderTextureWebGLRender

### DIFF
--- a/cocos2d/render-texture/CCRenderTextureWebGLRenderCmd.js
+++ b/cocos2d/render-texture/CCRenderTextureWebGLRenderCmd.js
@@ -256,7 +256,8 @@
         var viewPortRectHeightRatio = viewport.height / this._fullRect.height;
         viewport.x = (this._fullRect.x - this._rtTextureRect.x) * viewPortRectWidthRatio;
         viewport.y = (this._fullRect.y - this._rtTextureRect.y) * viewPortRectHeightRatio;
-        gl.viewport(viewport.x, viewport.y, viewport.width, viewport.height);
+        var locScaleFactor = cc.contentScaleFactor();
+        gl.viewport(viewport.x, viewport.y, viewport.width * locScaleFactor, viewport.height * locScaleFactor);
 
         this._oldFBO = gl.getParameter(gl.FRAMEBUFFER_BINDING);
         gl.bindFramebuffer(gl.FRAMEBUFFER, this._fBO);//Will direct drawing to the frame buffer created above


### PR DESCRIPTION
GL viewport did not account for content scale factor, which also resulted in a wrong projection.

For instance, this screenshot was taken with contentScaleFactor = 2. The `RenderTexture` node has a red clear color to make it easy to distinguish from the rest of the scene. It should contain a screenshot of the rest of the nodes. However, instead of them being centered, as in the real scene, they only use one quadrant in the screenshot. This PR fixes that bug.

![](https://i.imgur.com/brN3Dy1.jpg)

