### PR TITLE
Window resize event on browser not working

### DIFF
--- a/cocos2d/core/platform/CCEGLView.js
+++ b/cocos2d/core/platform/CCEGLView.js
@@ -187,6 +187,8 @@ cc.EGLView = cc.Class.extend(/** @lends cc.view# */{
 
         if (sys.isMobile) {
             window.addEventListener('orientationchange', this._orientationChange);
+        } else {
+            this._orientationChanging = false;
         }
     },
 


### PR DESCRIPTION
An alternative to #3523 , I thought of changing the variable _orientationChanging to false only when not running on mobile.