### PR TITLE
tilemap: Fixed calculation of tileset rows/columns

### DIFF
--- a/cocos2d/tilemap/CCTMXLayer.js
+++ b/cocos2d/tilemap/CCTMXLayer.js
@@ -129,8 +129,8 @@ cc.TMXLayer = cc.SpriteBatchNode.extend(/** @lends cc.TMXLayer# */{
             spacing = tileset.spacing,
             margin = tileset.margin,
 
-            cols = Math.floor((imageW - margin*2 + spacing) / (tw + spacing)),
-            rows = Math.floor((imageH - margin*2 + spacing) / (th + spacing)),
+            cols = Math.floor((imageW - margin + spacing) / (tw + spacing)),
+            rows = Math.floor((imageH - margin + spacing) / (th + spacing)),
             count = rows * cols,
 
             gid = tileset.firstGid,


### PR DESCRIPTION
The margin should only be subtracted once, since it’s irrelevant whether the margin exists also at the bottom or the right side of the image.

With this change it matches the behavior of Tiled.