### PR TITLE
Fix cc.ScrollView.WebGLRenderCmd._startCmd

### DIFF
--- a/extensions/gui/scrollview/CCScrollViewWebGLRenderCmd.js
+++ b/extensions/gui/scrollview/CCScrollViewWebGLRenderCmd.js
@@ -42,7 +42,7 @@
             node._scissorRestored = true;
             node._parentScissorRect = EGLViewer.getScissorRect();
             //set the intersection of m_tParentScissorRect and frame as the new scissor rect
-            if (cc.rectIntersection(frame, node._parentScissorRect)) {
+            if (cc.rectIntersectsRect(frame, node._parentScissorRect)) {
                 var locPSRect = node._parentScissorRect;
                 var x = Math.max(frame.x, locPSRect.x);
                 var y = Math.max(frame.y, locPSRect.y);


### PR DESCRIPTION
I found a bug in updating the scissor box of cc.ScrollView.WebGLRenderCmd.
The calling function is incorrect in the intersection judgment processing of parent scissor box and frame.
Since cc.rectIntersection always returns Rect Object, the expression of the if statement is always true.