### PR TITLE
Fix type in UIButton.js doc

### DIFF
--- a/extensions/ccui/uiwidgets/UIButton.js
+++ b/extensions/ccui/uiwidgets/UIButton.js
@@ -652,7 +652,7 @@ ccui.Button = ccui.Widget.extend(/** @lends ccui.Button# */{
 
     /**
      * Sets title fontSize to ccui.Button
-     * @param {cc.Size} size
+     * @param {Number} size
      */
     setTitleFontSize: function (size) {
         this._createTitleRendererIfNeeded();


### PR DESCRIPTION
Wrong argument type in UIButton.js setTitleFontSize method.