### PR TITLE
cc.PI2 moved to CCMacro.js to make it more consistent with other constants

### DIFF
--- a/cocos2d/core/CCDrawingPrimitivesCanvas.js
+++ b/cocos2d/core/CCDrawingPrimitivesCanvas.js
@@ -24,12 +24,6 @@
  THE SOFTWARE.
  ****************************************************************************/
 /**
- * @const
- * @type {number}
- */
-cc.PI2 = Math.PI * 2;
-
-/**
  * Canvas of DrawingPrimitive implement version use for canvasMode
  * @class
  * @extends cc.Class

--- a/cocos2d/core/platform/CCMacro.js
+++ b/cocos2d/core/platform/CCMacro.js
@@ -41,6 +41,12 @@ cc.PI = Math.PI;
  * @constant
  * @type Number
  */
+cc.PI2 = Math.PI * 2;
+
+/**
+ * @constant
+ * @type Number
+ */
 cc.FLT_MAX = parseFloat('3.402823466e+38F');
 
 /**


### PR DESCRIPTION
The constant cc.PI2 was declared in `CCDrawingPrimitivesCanvas.js`, since it was only used on that file. But it would be better placed next to cc.PI, on CCMacro.js