### PR TITLE
修改粒子特效bug

### DIFF
--- a/cocos2d/particle/CCParticleBatchNodeWebGLRenderCmd.js
+++ b/cocos2d/particle/CCParticleBatchNodeWebGLRenderCmd.js
@@ -52,6 +52,7 @@
         this._glProgramState.apply(this._matrix);
         cc.glBlendFuncForParticle(_t._blendFunc.src, _t._blendFunc.dst);
         _t.textureAtlas.drawQuads();
+        cc.glBlendResetToCache();
     };
 
     proto._initWithTexture = function () {

--- a/cocos2d/particle/CCParticleSystem.js
+++ b/cocos2d/particle/CCParticleSystem.js
@@ -595,7 +595,8 @@ cc.ParticleSystem = cc.Node.extend(/** @lends cc.ParticleSystem# */{
     setGravity: function (gravity) {
         if (this.emitterMode !== cc.ParticleSystem.MODE_GRAVITY)
             cc.log("cc.ParticleBatchNode.setGravity() : Particle Mode should be Gravity");
-        this.modeA.gravity = gravity;
+        this.modeA.gravity.x = gravity.x;
+        this.modeA.gravity.y = gravity.y;
     },
 
     /**

--- a/cocos2d/particle/CCParticleSystemWebGLRenderCmd.js
+++ b/cocos2d/particle/CCParticleSystemWebGLRenderCmd.js
@@ -223,6 +223,7 @@
 
         gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this._buffersVBO[1]);
         gl.drawElements(gl.TRIANGLES, node._particleIdx * 6, gl.UNSIGNED_SHORT, 0);
+        cc.glBlendResetToCache();
     };
 
     proto.initTexCoordsWithRect = function (pointRect) {


### PR DESCRIPTION
1.粒子特效的重力设置方法有问题，导致重力被改变。
2.粒子特效调用glBlendFuncForParticle来调用混合方法blendFuncSeparate，如果后面的图片使用一样的混合因子，就会继续使用blendFuncSeparate方法，导致图片混合不对