### PR TITLE
make cocos2d 'strict mode' compatible

### DIFF
--- a/cocos2d/core/platform/CCInputExtension.js
+++ b/cocos2d/core/platform/CCInputExtension.js
@@ -136,4 +136,4 @@ _p.didAccelerate = function (eventData) {
     }
 };
 
-delete _p;
+_p = null;


### PR DESCRIPTION
fix the following error when in 'strict mode':
`Module parse failed: Deleting local variable in strict mode`