### PR TITLE
Save cache render cache flag from renderer when using RenderTexture

### DIFF
--- a/cocos2d/render-texture/CCRenderTexture.js
+++ b/cocos2d/render-texture/CCRenderTexture.js
@@ -202,7 +202,6 @@ cc.RenderTexture = cc.Node.extend(/** @lends cc.RenderTexture# */{
      * @function
      */
     begin: function () {
-        cc.renderer._turnToCacheMode(this.__instanceId);
         this._renderCmd.begin();
     },
     /**

--- a/cocos2d/render-texture/CCRenderTextureCanvasRenderCmd.js
+++ b/cocos2d/render-texture/CCRenderTextureCanvasRenderCmd.js
@@ -28,6 +28,8 @@
         this._needDraw = false;
         this._clearColorStr = "rgba(255,255,255,1)";
 
+        this._oldIsCacheToCanvasOn = false;
+
         this._cacheCanvas = document.createElement('canvas');
         this._cacheContext = new cc.CanvasContextWrapper(this._cacheCanvas.getContext('2d'));
     };
@@ -70,6 +72,8 @@
     };
 
     proto.begin = function () {
+        this._oldIsCacheToCanvasOn = cc.renderer._isCacheToCanvasOn;
+        cc.renderer._turnToCacheMode(node.__instanceId);
     };
 
     proto._beginWithClear = function (r, g, b, a, depthValue, stencilValue, flags) {
@@ -91,6 +95,9 @@
 
         var scale = cc.contentScaleFactor();
         cc.renderer._renderingToCacheCanvas(this._cacheContext, node.__instanceId, scale, scale);
+
+        cc.renderer._isCacheToCanvasOn = this._oldIsCacheToCanvasOn;
+
         var spriteRenderCmd = node.sprite._renderCmd;
         spriteRenderCmd._notifyRegionStatus && spriteRenderCmd._notifyRegionStatus(cc.Node.CanvasRenderCmd.RegionStatus.Dirty);
     };

--- a/cocos2d/render-texture/CCRenderTextureWebGLRenderCmd.js
+++ b/cocos2d/render-texture/CCRenderTextureWebGLRenderCmd.js
@@ -29,6 +29,7 @@
 
         this._fBO = null;
         this._oldFBO = null;
+        this._oldIsCacheToBufferOn = false;
         this._textureCopy = null;
         this._depthRenderBuffer = null;
 
@@ -226,6 +227,10 @@
 
     proto.begin = function () {
         var node = this._node;
+
+        this._oldIsCacheToBufferOn = cc.renderer._isCacheToBufferOn;
+        cc.renderer._turnToCacheMode(node.__instanceId);
+
         // Save the current matrix
         cc.kmGLMatrixMode(cc.KM_GL_PROJECTION);
         cc.kmGLPushMatrix();
@@ -319,6 +324,8 @@
     proto.end = function () {
         var node = this._node;
         cc.renderer._renderingToBuffer(node.__instanceId);
+
+        cc.renderer._isCacheToBufferOn = this._oldIsCacheToBufferOn;
 
         var gl = cc._renderContext;
         var director = cc.director;


### PR DESCRIPTION
RenderTexture render cmd do not correctly save cache flag of render cmd's of renderer and as result some render command are placed in cache, not in `_renderCmds` array.

**Test case for reproduce:**
Scene has for example a scroll view (it enables cache flag on visit with `cc.renderer_turnToCacheMode`) and sprites on background (zOrder < scroll.zOrder)
Render texture is created and placed on ScrollView some time after (e.g. data for is loaded from network or clicking some button) adding scroll view to scene (must be passed one loop of `cc.director`).
As a result scene doesn't render background sprites after using render texture (`begin() - end() `pair).

Test scene code (for js-test from cocos2d-x)

```
var RenderTextureWithScrollView = RenderTextureBaseLayer.extend({
    _scroll: null,

    ctor:function() {
        this._super();

        var backSprite = new cc.Sprite(s_back1);

        backSprite.x = winSize.width/2;
        backSprite.y = winSize.height/2;

        this.addChild(backSprite, 1);

        this._scroll = new ccui.ListView();
        this._scroll.setDirection(ccui.ScrollView.DIR_HORIZONTAL);
        this._scroll.setContentSize(winSize.width, winSize.height);
        this._scroll.setPosition(winSize.width/4, winSize.height/4);
        this._scroll.setBounceEnabled(true);

        this.addChild(this._scroll, 2);

        var callfunc = cc.callFunc(this._addRenderTextureNode, this);

        this.runAction(cc.sequence(cc.delayTime(0.1), callfunc));
    },

    _addRenderTextureNode: function()
    {
        var sprite = new cc.Sprite(s_grossini);

        // create a render texture
        var rend = new cc.RenderTexture( winSize.width/2, winSize.height/2 );

        sprite.x = winSize.width/2;
        sprite.y = 3*winSize.height/4;

        rend.begin();
        sprite.visit();
        rend.end();

        var texture = rend.getSprite().getTexture();
        var spr = new cc.Sprite(texture);
        spr.setScaleY(-1);
        spr.setAnchorPoint(0, 0);

        var layout = new ccui.Layout();
        layout.addChild(spr);
        layout.setContentSize(spr.getContentSize());

        this._scroll.pushBackCustomItem(layout);
    },

    title:function () {
        return "Render Texture and ScrollView";
    },

    subtitle:function () {
        return "Background and rendered sprites must be visible, not a black screen";
    }
});
```